### PR TITLE
set go version to 1.23.3 explicitly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crowdsecurity/crowdsec-cloudflare-worker-bouncer
 
-go 1.23
+go 1.23.3
 
 require (
 	github.com/crowdsecurity/crowdsec v1.6.3


### PR DESCRIPTION
Since the introduction of toolchains in go, it is recommended to specify the full version as the go version so the `go` binary can automatically download the proper version without requiring a `toolchain` directive (it will fail with an error saying it cannot find the toolchain otherwise)