### PR TITLE
refactor zone retrieval logic to unhandle unknown zones

### DIFF
--- a/pkg/cloudflare/worker/worker.js
+++ b/pkg/cloudflare/worker/worker.js
@@ -270,17 +270,22 @@ export default {
 
     await incrementMetrics("processed", ipType)
 
+    if (typeof env.ACTIONS_BY_DOMAIN === "string") {
+      env.ACTIONS_BY_DOMAIN = JSON.parse(env.ACTIONS_BY_DOMAIN)
+    }
+    const zoneForThisRequest = getZoneFromReqURL(request.url, env.ACTIONS_BY_DOMAIN);
+    if (!zoneForThisRequest) {
+      console.log("No zone found for this request")
+      return fetch(request)
+    }else {
+      console.log("Zone for this request is " + zoneForThisRequest)
+    }
 
     let remediation = await getRemediationForRequest(request, env)
     if (remediation === null) {
       console.log("No remediation found for request")
       return fetch(request)
     }
-    if (typeof env.ACTIONS_BY_DOMAIN === "string") {
-      env.ACTIONS_BY_DOMAIN = JSON.parse(env.ACTIONS_BY_DOMAIN)
-    }
-    const zoneForThisRequest = getZoneFromReqURL(request.url, env.ACTIONS_BY_DOMAIN);
-    console.log("Zone for this request is " + zoneForThisRequest)
     remediation = getSupportedActionForZone(remediation, env.ACTIONS_BY_DOMAIN[zoneForThisRequest])
     console.log("Remediation for request is " + remediation)
     switch (remediation) {


### PR DESCRIPTION
This PR refactors the Cloudflare Worker's zone handling logic in `worker.js` to prevent exceptions when requests for unknown zones are processed.

Added explicit handling for cases where no zone is found for a request:
- If getZoneFromReqURL() returns null/undefined, the worker now logs "No zone found for this request" and passes the request through unchanged using return fetch(request)
- This prevents further processing for domains that aren't configured
- This also prevents unnecessary KV reads for unknown zones and will early exit