### PR TITLE
feat(metrics): migrate worker metrics from D1 to Workers Analytics Engine

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -154,7 +154,7 @@ func cleanUp(managers []*cf.CloudflareAccountManager, c context.CancelFunc, ctx 
 		manager := m
 		manager.Ctx = context.Background()
 		g.Go(func() error {
-			return manager.CleanUpExistingWorkers(false)
+			return manager.CleanUpExistingWorkers()
 		})
 	}
 	if err := g.Wait(); err != nil {
@@ -235,7 +235,7 @@ func deployInfraForManagers(g *errgroup.Group, cfManagers []*cf.CloudflareAccoun
 	for _, cfManager := range cfManagers {
 		manager := cfManager
 		g.Go(func() error {
-			err := manager.CleanUpExistingWorkers(true)
+			err := manager.CleanUpExistingWorkers()
 			if err != nil {
 				return fmt.Errorf("unable to cleanup existing workers: %w for account %s", err, manager.AccountCfg.Name)
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,16 +138,12 @@ func (m *metricsHandler) metricsUpdater(met *models.RemediationComponentsMetrics
 	}
 }
 
-func (m *metricsHandler) computeMetricsHandler(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		for _, manager := range m.cfManagers {
-			err := manager.UpdateMetrics()
-			if err != nil {
-				log.Errorf("unable to update metrics for account %s: %s", manager.AccountCfg.Name, err)
-			}
-		}
-		next.ServeHTTP(w, r)
-	})
+// computeMetricsHandler is a pass-through. UpdateMetrics is driven solely by
+// metricsUpdater on the csbouncer push schedule; polling AE from the scrape
+// path too would give two callers one shared lastMetricsPoll cursor and couple
+// scrape latency to AE API latency.
+func (*metricsHandler) computeMetricsHandler(next http.Handler) http.Handler {
+	return next
 }
 
 func cleanUp(managers []*cf.CloudflareAccountManager, c context.CancelFunc, ctx context.Context) {
@@ -390,7 +386,8 @@ func Execute(opts ExecuteOptions) error {
 	})
 
 	prometheus.MustRegister(csbouncer.TotalLAPICalls, csbouncer.TotalLAPIError, metrics.CloudflareAPICallsByAccount, metrics.TotalKeysByAccount,
-		metrics.TotalActiveDecisions, metrics.TotalBlockedRequests, metrics.TotalProcessedRequests)
+		metrics.TotalActiveDecisions, metrics.TotalBlockedRequests, metrics.TotalProcessedRequests, metrics.AverageLatencyMs,
+		metrics.TotalErrors)
 	if conf.PrometheusConfig.Enabled {
 		g.Go(func() error {
 			http.Handle("/metrics", mHandler.computeMetricsHandler(promhttp.Handler()))

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -121,7 +121,7 @@ func runInfraTest(t *testing.T, m *cf.CloudflareAccountManager) error {
 }
 
 func runCleanUpTest(t *testing.T, m *cf.CloudflareAccountManager) error {
-	if err := m.CleanUpExistingWorkers(false); err != nil {
+	if err := m.CleanUpExistingWorkers(); err != nil {
 		return err
 	}
 	api, err := apiFromManager(m)

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -19,6 +21,21 @@ import (
 var (
 	VarNameForActionsByDomain = "ACTIONS_BY_DOMAIN"
 	ErrEmptyConfig            = errors.New("empty config")
+)
+
+// validAccountName / validAnalyticsDataset enforce that values interpolated into
+// the AE SQL query cannot break out of a ClickHouse string literal or identifier
+// context. Rejecting at config load eliminates the need for runtime escaping.
+var (
+	validAccountName      = regexp.MustCompile(`^[\p{L}\p{N} ._\-()&+@:,]*$`)
+	validAnalyticsDataset = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]{0,63}$`)
+)
+
+// KVWorkerBindingName and AEWorkerBindingName are the worker env binding names hardcoded in the
+// compiled worker JS. They must not be changed without also updating the worker source.
+const (
+	KVWorkerBindingName = "CROWDSECCFBOUNCERNS"
+	AEWorkerBindingName = "CROWDSECCFBOUNCER_AE"
 )
 
 type TurnstileConfig struct {
@@ -50,15 +67,27 @@ type AccountConfig struct {
 // YAML struct derived from cloudflare.CreateWorkerParams
 // https://github.com/cloudflare/cloudflare-go/blob/056b65c6e956a7119d0d89b27a659ea63b1c0506/workers.go#L24
 type CloudflareWorkerCreateParams struct {
-	ScriptName              string   `yaml:"script_name"`
-	Logpush                 *bool    `yaml:"logpush"`
-	Tags                    []string `yaml:"tags"`
-	CompatibilityDate       string   `yaml:"compatibility_date"`
-	CompatibilityFlags      []string `yaml:"compatibility_flags"`
-	LogOnly                 bool     `yaml:"log_only"`
-	KVNameSpaceName         string   `yaml:"-"` // Currently hardcoded string in worker code but may allow customization in future
-	D1DBName                string   `yaml:"-"` // Hardcoded, internal implementation detail for metrics support
-	DecisionsSyncScriptName string   `yaml:"-"` // Hardcoded, internal implementation detail for autonomous mode
+	ScriptName              string                     `yaml:"script_name"`
+	Logpush                 *bool                      `yaml:"logpush"`
+	Tags                    []string                   `yaml:"tags"`
+	CompatibilityDate       string                     `yaml:"compatibility_date"`
+	CompatibilityFlags      []string                   `yaml:"compatibility_flags"`
+	LogOnly                 bool                       `yaml:"log_only"`
+	KVNameSpaceName         string                     `yaml:"kv_namespace_name,omitempty"`          // CF resource title used for create/delete lookup; change when sharing a Cloudflare account with another bouncer instance
+	AnalyticsDataset        string                     `yaml:"analytics_dataset,omitempty"`          // CF Analytics Engine dataset name for metrics
+	DecisionsSyncScriptName string                     `yaml:"decisions_sync_script_name,omitempty"` // CF worker script name; change when sharing a Cloudflare account with another bouncer instance
+	Observability           *WorkerObservabilityConfig `yaml:"observability,omitempty"`              // Workers Observability (logs + traces); nil = skip
+}
+
+type WorkerObservabilityConfig struct {
+	Enabled          *bool               `yaml:"enabled"`
+	HeadSamplingRate *float64            `yaml:"head_sampling_rate"`
+	Traces           *WorkerTracesConfig `yaml:"traces,omitempty"`
+}
+
+type WorkerTracesConfig struct {
+	Enabled          *bool    `yaml:"enabled"`
+	HeadSamplingRate *float64 `yaml:"head_sampling_rate"`
 }
 
 func (w *CloudflareWorkerCreateParams) setDefaults() {
@@ -68,29 +97,29 @@ func (w *CloudflareWorkerCreateParams) setDefaults() {
 	if w.KVNameSpaceName == "" {
 		w.KVNameSpaceName = "CROWDSECCFBOUNCERNS"
 	}
-	if w.D1DBName == "" {
-		w.D1DBName = "CROWDSECCFBOUNCERDB"
+	if w.AnalyticsDataset == "" {
+		w.AnalyticsDataset = "crowdsec_cloudflare_bouncer"
 	}
 	if w.DecisionsSyncScriptName == "" {
 		w.DecisionsSyncScriptName = "crowdsec-decisions-sync-worker"
 	}
 }
 
-func (w *CloudflareWorkerCreateParams) CreateWorkerParams(workerScript string, id string, varActionsForZoneByDomain []byte, dbID string) cloudflare.CreateWorkerParams {
+func (w *CloudflareWorkerCreateParams) CreateWorkerParams(workerScript string, id string, varActionsForZoneByDomain []byte, accountName string) cloudflare.CreateWorkerParams {
 	bindings := map[string]cloudflare.WorkerBinding{
-		w.KVNameSpaceName: cloudflare.WorkerKvNamespaceBinding{NamespaceID: id},
+		KVWorkerBindingName: cloudflare.WorkerKvNamespaceBinding{NamespaceID: id},
 		VarNameForActionsByDomain: cloudflare.WorkerPlainTextBinding{
 			Text: string(varActionsForZoneByDomain),
 		},
 		"LOG_ONLY": cloudflare.WorkerPlainTextBinding{
 			Text: fmt.Sprintf("%t", w.LogOnly),
 		},
-	}
-
-	if dbID != "" {
-		bindings[w.D1DBName] = cloudflare.WorkerD1DatabaseBinding{
-			DatabaseID: dbID,
-		}
+		AEWorkerBindingName: cloudflare.WorkerAnalyticsEngineBinding{
+			Dataset: w.AnalyticsDataset,
+		},
+		"ACCOUNT_NAME": cloudflare.WorkerPlainTextBinding{
+			Text: accountName,
+		},
 	}
 	return cloudflare.CreateWorkerParams{
 		Script:             workerScript,
@@ -178,7 +207,8 @@ func NewConfig(reader io.Reader) (*BouncerConfig, error) {
 	validAction := map[string]bool{"captcha": true, "ban": true}
 	validChoiceMsg := "valid choices are either of 'ban', 'captcha'"
 
-	for _, account := range config.CloudflareConfig.Accounts {
+	for i := range config.CloudflareConfig.Accounts {
+		account := &config.CloudflareConfig.Accounts[i]
 		if _, ok := accountIDSet[account.ID]; ok {
 			return nil, fmt.Errorf("the account '%s' is duplicated", account.ID)
 		}
@@ -188,8 +218,17 @@ func NewConfig(reader io.Reader) (*BouncerConfig, error) {
 			return nil, fmt.Errorf("the account '%s' is missing token", account.ID)
 		}
 
+		// Mirror the worker's `env.ACCOUNT_NAME || "default"` fallback: an empty
+		// name would query `index1 = ''` and never match what the worker writes.
+		if account.Name == "" {
+			account.Name = "default"
+		}
+		if !validAccountName.MatchString(account.Name) {
+			return nil, fmt.Errorf("account '%s' has invalid account_name %q: permitted characters are letters, digits, spaces, and . _ - ( ) & + @ : ,", account.ID, account.Name)
+		}
+
 		for _, zone := range account.ZoneConfigs {
-			if !stringSliceContains(zone.Actions, zone.DefaultAction) {
+			if !slices.Contains(zone.Actions, zone.DefaultAction) {
 				zone.Actions = append(zone.Actions, zone.DefaultAction)
 			}
 			if len(zone.Actions) == 0 {
@@ -210,16 +249,23 @@ func NewConfig(reader io.Reader) (*BouncerConfig, error) {
 		}
 	}
 	config.CloudflareConfig.Worker.setDefaults() // set defaults for worker
-	return config, nil
-}
 
-func stringSliceContains(slice []string, t string) bool {
-	for _, item := range slice {
-		if item == t {
-			return true
+	if !validAnalyticsDataset.MatchString(config.CloudflareConfig.Worker.AnalyticsDataset) {
+		return nil, fmt.Errorf("invalid analytics_dataset %q: must match %s", config.CloudflareConfig.Worker.AnalyticsDataset, validAnalyticsDataset.String())
+	}
+
+	if obs := config.CloudflareConfig.Worker.Observability; obs != nil {
+		if r := obs.HeadSamplingRate; r != nil && (*r < 0 || *r > 1) {
+			return nil, fmt.Errorf("observability head_sampling_rate must be between 0 and 1, got %f", *r)
+		}
+		if obs.Traces != nil {
+			if r := obs.Traces.HeadSamplingRate; r != nil && (*r < 0 || *r > 1) {
+				return nil, fmt.Errorf("observability traces head_sampling_rate must be between 0 and 1, got %f", *r)
+			}
 		}
 	}
-	return false
+
+	return config, nil
 }
 
 func lineComment(l string, zoneByID map[string]cloudflare.Zone, accountByID map[string]cloudflare.Account) string {
@@ -249,11 +295,26 @@ func lineComment(l string, zoneByID map[string]cloudflare.Zone, accountByID map[
 	if strings.Contains(l, "turnstile:") {
 		return `Turnstile must be enabled if captcha action is used.`
 	}
+	if strings.Contains(l, "kv_namespace_name:") {
+		return `KV namespace title used to create/locate the decision store; change when running multiple bouncers on the same Cloudflare account`
+	}
+	if strings.Contains(l, "decisions_sync_script_name:") {
+		return `Decisions sync worker script name; change when running multiple bouncers on the same Cloudflare account`
+	}
 	if strings.Contains(l, "decisions_sync_worker:") {
 		return `Configuration for autonomous decisions sync worker`
 	}
 	if strings.Contains(l, "cron:") {
 		return `Cron schedule for syncing decisions (e.g., "*/5 * * * *" for every 5 minutes)`
+	}
+	if strings.Contains(l, "analytics_dataset:") {
+		return `Workers Analytics Engine dataset name that the worker writes metric data points to`
+	}
+	if strings.Contains(l, "observability:") {
+		return `Workers Observability (logs/traces) configuration; omit to leave Cloudflare defaults in place`
+	}
+	if strings.Contains(l, "head_sampling_rate:") {
+		return `Sampling rate for head-based observability (0.0 to 1.0)`
 	}
 	return ""
 }
@@ -280,7 +341,7 @@ func ConfigTokens(tokens string, baseConfigPath string) (string, error) {
 	accountByID := make(map[string]cloudflare.Account)
 	accountIDXByID := make(map[string]int)
 	ctx := context.Background()
-	for _, token := range strings.Split(tokens, ",") {
+	for token := range strings.SplitSeq(tokens, ",") {
 		api, err := cloudflare.NewWithAPIToken(token)
 		if err != nil {
 			return "", fmt.Errorf("failed to create cloudflare api client: %w", err)
@@ -296,9 +357,19 @@ func ConfigTokens(tokens string, baseConfigPath string) (string, error) {
 		for _, account := range accounts {
 			accountByID[account.ID] = account
 			if _, ok := accountIDXByID[account.ID]; !ok {
+				// The Cloudflare-supplied account name flows into the AE SQL
+				// query, so it must satisfy validAccountName. A name that
+				// doesn't (e.g. "O'Brien") would generate a config that
+				// NewConfig rejects on the next startup — fall back to the
+				// account ID, which is always a safe identifier.
+				name := strings.Replace(account.Name, "'s Account", "", -1)
+				if !validAccountName.MatchString(name) {
+					log.Warnf("Cloudflare account name %q contains unsupported characters; using account ID %q as account_name", account.Name, account.ID)
+					name = account.ID
+				}
 				accountConfigs = append(accountConfigs, AccountConfig{
 					ID:          account.ID,
-					Name:        strings.Replace(account.Name, "'s Account", "", -1),
+					Name:        name,
 					ZoneConfigs: make([]*ZoneConfig, 0),
 					Token:       token,
 					BanTemplate: "",

--- a/pkg/cfg/config_test.go
+++ b/pkg/cfg/config_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"path"
+	"strings"
 	"testing"
 
+	"github.com/cloudflare/cloudflare-go"
 	"github.com/crowdsecurity/crowdsec-cloudflare-worker-bouncer/pkg/cfg"
 )
 
@@ -42,6 +44,263 @@ func TestConfig(t *testing.T) {
 					t.Fatalf("expected error %s, got %s", tt.err, err)
 				}
 				return
+			}
+		})
+	}
+}
+
+func TestCreateWorkerParams_AEBinding(t *testing.T) {
+	w := &cfg.CloudflareWorkerCreateParams{
+		AnalyticsDataset: "crowdsec_cloudflare_bouncer",
+	}
+
+	params := w.CreateWorkerParams("script", "kv-ns-id", []byte(`{}`), "test-account")
+
+	binding, ok := params.Bindings[cfg.AEWorkerBindingName]
+	if !ok {
+		t.Fatal("AE binding missing from CreateWorkerParams")
+	}
+
+	aeBinding, ok := binding.(cloudflare.WorkerAnalyticsEngineBinding)
+	if !ok {
+		t.Fatalf("AE binding is %T, want WorkerAnalyticsEngineBinding", binding)
+	}
+
+	if aeBinding.Dataset != "crowdsec_cloudflare_bouncer" {
+		t.Fatalf("AE dataset = %q, want %q", aeBinding.Dataset, "crowdsec_cloudflare_bouncer")
+	}
+}
+
+func TestCreateWorkerParams_AccountNameBinding(t *testing.T) {
+	w := &cfg.CloudflareWorkerCreateParams{}
+
+	params := w.CreateWorkerParams("script", "kv-ns-id", []byte(`{}`), "Acme Corp")
+
+	binding, ok := params.Bindings["ACCOUNT_NAME"]
+	if !ok {
+		t.Fatal("ACCOUNT_NAME binding missing from CreateWorkerParams")
+	}
+
+	ptBinding, ok := binding.(cloudflare.WorkerPlainTextBinding)
+	if !ok {
+		t.Fatalf("ACCOUNT_NAME binding is %T, want WorkerPlainTextBinding", binding)
+	}
+
+	if ptBinding.Text != "Acme Corp" {
+		t.Fatalf("ACCOUNT_NAME = %q, want %q", ptBinding.Text, "Acme Corp")
+	}
+}
+
+func TestSetDefaults_AnalyticsDataset(t *testing.T) {
+	yamlCfg := []byte(`
+crowdsec_config:
+  lapi_url: http://localhost:8080/
+  lapi_key: test-key
+  update_frequency: 10s
+cloudflare_config:
+  accounts:
+    - id: acc1
+      token: tok1
+      zones:
+        - zone_id: zone1
+          actions: ["ban"]
+          default_action: ban
+          routes_to_protect: ["*example.com/*"]
+`)
+
+	config, err := cfg.NewConfig(bytes.NewReader(yamlCfg))
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+
+	if config.CloudflareConfig.Worker.AnalyticsDataset != "crowdsec_cloudflare_bouncer" {
+		t.Fatalf("AnalyticsDataset = %q, want %q", config.CloudflareConfig.Worker.AnalyticsDataset, "crowdsec_cloudflare_bouncer")
+	}
+}
+
+func TestObservabilityConfig_NilByDefault(t *testing.T) {
+	yamlCfg := []byte(`
+crowdsec_config:
+  lapi_url: http://localhost:8080/
+  lapi_key: test-key
+  update_frequency: 10s
+cloudflare_config:
+  accounts:
+    - id: acc1
+      token: tok1
+      zones:
+        - zone_id: zone1
+          actions: ["ban"]
+          default_action: ban
+          routes_to_protect: ["*example.com/*"]
+`)
+
+	config, err := cfg.NewConfig(bytes.NewReader(yamlCfg))
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+
+	if config.CloudflareConfig.Worker.Observability != nil {
+		t.Fatal("Observability should be nil by default")
+	}
+}
+
+func TestObservabilityConfig_ParsesFromYAML(t *testing.T) {
+	yamlCfg := []byte(`
+crowdsec_config:
+  lapi_url: http://localhost:8080/
+  lapi_key: test-key
+  update_frequency: 10s
+cloudflare_config:
+  worker:
+    observability:
+      enabled: true
+      head_sampling_rate: 0.5
+      traces:
+        enabled: true
+        head_sampling_rate: 0.1
+  accounts:
+    - id: acc1
+      token: tok1
+      zones:
+        - zone_id: zone1
+          actions: ["ban"]
+          default_action: ban
+          routes_to_protect: ["*example.com/*"]
+`)
+
+	config, err := cfg.NewConfig(bytes.NewReader(yamlCfg))
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+
+	obs := config.CloudflareConfig.Worker.Observability
+	if obs == nil {
+		t.Fatal("Observability should not be nil")
+	}
+	if obs.Enabled == nil || !*obs.Enabled {
+		t.Error("Enabled should be true")
+	}
+	if obs.HeadSamplingRate == nil || *obs.HeadSamplingRate != 0.5 {
+		t.Errorf("HeadSamplingRate = %v, want 0.5", obs.HeadSamplingRate)
+	}
+
+	if obs.Traces == nil {
+		t.Fatal("Traces should not be nil")
+	}
+	if obs.Traces.Enabled == nil || !*obs.Traces.Enabled {
+		t.Error("Traces.Enabled should be true")
+	}
+	if obs.Traces.HeadSamplingRate == nil || *obs.Traces.HeadSamplingRate != 0.1 {
+		t.Errorf("Traces.HeadSamplingRate = %v, want 0.1", obs.Traces.HeadSamplingRate)
+	}
+}
+
+func TestObservabilityConfig_InvalidSamplingRate(t *testing.T) {
+	yamlCfg := []byte(`
+crowdsec_config:
+  lapi_url: http://localhost:8080/
+  lapi_key: test-key
+  update_frequency: 10s
+cloudflare_config:
+  worker:
+    observability:
+      enabled: true
+      head_sampling_rate: 5.0
+  accounts:
+    - id: acc1
+      token: tok1
+      zones:
+        - zone_id: zone1
+          actions: ["ban"]
+          default_action: ban
+          routes_to_protect: ["*example.com/*"]
+`)
+
+	_, err := cfg.NewConfig(bytes.NewReader(yamlCfg))
+	if err == nil {
+		t.Fatal("expected error for invalid sampling rate")
+	}
+	if !strings.Contains(err.Error(), "head_sampling_rate must be between 0 and 1") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// configWith builds a minimal valid bouncer config. A non-empty accountName is
+// injected as account_name; a non-empty dataset as worker.analytics_dataset.
+func configWith(accountName, dataset string) []byte {
+	worker := ""
+	if dataset != "" {
+		worker = "  worker:\n    analytics_dataset: \"" + dataset + "\"\n"
+	}
+	name := ""
+	if accountName != "" {
+		name = "      account_name: \"" + accountName + "\"\n"
+	}
+	return []byte("\n" +
+		"crowdsec_config:\n" +
+		"  lapi_url: http://localhost:8080/\n" +
+		"  lapi_key: test-key\n" +
+		"  update_frequency: 10s\n" +
+		"cloudflare_config:\n" +
+		worker +
+		"  accounts:\n" +
+		"    - id: acc1\n" +
+		"      token: tok1\n" +
+		name +
+		"      zones:\n" +
+		"        - zone_id: zone1\n" +
+		"          actions: [\"ban\"]\n" +
+		"          default_action: ban\n" +
+		"          routes_to_protect: [\"*example.com/*\"]\n")
+}
+
+func TestAccountName_RejectsInjectionCharacters(t *testing.T) {
+	// Each payload carries a character that can break out of the AE SQL string
+	// literal ( ' or \ ); validation must reject all of them at config load.
+	cases := map[string]string{
+		"single quote": `O'Brien`,
+		"backslash":    `foo\\bar`,
+		"injection":    `foo'; DROP TABLE users; --`,
+	}
+	for name, payload := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := cfg.NewConfig(bytes.NewReader(configWith(payload, "")))
+			if err == nil || !strings.Contains(err.Error(), "invalid account_name") {
+				t.Fatalf("expected 'invalid account_name' rejection for %q, got: %v", payload, err)
+			}
+		})
+	}
+}
+
+func TestAccountName_AcceptsRealisticNames(t *testing.T) {
+	for _, name := range []string{"acme-prod", "Acme Corp", "Internal & External (prod)", "Acme + Co.", "owner@example.com"} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := cfg.NewConfig(bytes.NewReader(configWith(name, ""))); err != nil {
+				t.Errorf("NewConfig rejected valid name %q: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestAccountName_EmptyDefaultsToDefault(t *testing.T) {
+	// An omitted account_name must become "default" so the AE query's
+	// index1 filter matches the worker's `env.ACCOUNT_NAME || "default"`.
+	c, err := cfg.NewConfig(bytes.NewReader(configWith("", "")))
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+	if got := c.CloudflareConfig.Accounts[0].Name; got != "default" {
+		t.Errorf("empty account_name = %q, want \"default\"", got)
+	}
+}
+
+func TestAnalyticsDataset_RejectsInvalidIdentifiers(t *testing.T) {
+	for _, ds := range []string{"foo-bar", "foo bar", "1starts-with-digit", "foo;DROP", "foo'bar"} {
+		t.Run(ds, func(t *testing.T) {
+			_, err := cfg.NewConfig(bytes.NewReader(configWith("", ds)))
+			if err == nil || !strings.Contains(err.Error(), "invalid analytics_dataset") {
+				t.Fatalf("expected 'invalid analytics_dataset' rejection for %q, got: %v", ds, err)
 			}
 		})
 	}

--- a/pkg/cloudflare/cloudflare.go
+++ b/pkg/cloudflare/cloudflare.go
@@ -1,11 +1,13 @@
 package cf
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -28,14 +30,22 @@ var workerScript string
 //go:embed decisions-sync-worker/dist/main.js
 var decisionsSyncWorkerScript string
 
-//go:embed metrics.sql
-var sqlCreateTableStatement string
-
 const (
 	WidgetName            = "crowdsec-cloudflare-worker-bouncer-widget"
 	TurnstileConfigKey    = "TURNSTILE_CONFIG"
 	VarNameForBanTemplate = "BAN_TEMPLATE"
 	IpRangeKeyName        = "IP_RANGES"
+
+	// metricsPollLookback is how far back the AE metrics cursor reaches when
+	// the manager is freshly constructed, so the first poll covers any AE
+	// data points written between bouncer start and the first push cycle.
+	metricsPollLookback = 2 * time.Minute
+
+	// aeIngestionLag is how far in the past windowEnd lands relative to wall
+	// clock, so the [start, end) window only covers AE rows that have had time
+	// to index. Without this, the cursor advances past unindexed rows that
+	// arrive seconds late and the corresponding metrics are dropped forever.
+	aeIngestionLag = 10 * time.Second
 )
 
 type cloudflareAPI interface {
@@ -49,6 +59,7 @@ type cloudflareAPI interface {
 	DeleteWorkersKVEntries(ctx context.Context, rc *cf.ResourceContainer, params cf.DeleteWorkersKVEntriesParams) (cf.Response, error)
 	DeleteWorkersKVNamespace(ctx context.Context, rc *cf.ResourceContainer, namespaceID string) (cf.Response, error)
 	ListTurnstileWidgets(ctx context.Context, rc *cf.ResourceContainer, params cf.ListTurnstileWidgetParams) ([]cf.TurnstileWidget, *cf.ResultInfo, error)
+	ListWorkerBindings(ctx context.Context, rc *cf.ResourceContainer, params cf.ListWorkerBindingsParams) (cf.WorkerBindingListResponse, error)
 	ListWorkerRoutes(ctx context.Context, rc *cf.ResourceContainer, params cf.ListWorkerRoutesParams) (cf.WorkerRoutesResponse, error)
 	ListWorkersKVNamespaces(ctx context.Context, rc *cf.ResourceContainer, params cf.ListWorkersKVNamespacesParams) ([]cf.WorkersKVNamespace, *cf.ResultInfo, error)
 	ListWorkersSecrets(ctx context.Context, rc *cf.ResourceContainer, params cf.ListWorkersSecretsParams) (cf.WorkersListSecretsResponse, error)
@@ -58,10 +69,10 @@ type cloudflareAPI interface {
 	UploadWorker(ctx context.Context, rc *cf.ResourceContainer, params cf.CreateWorkerParams) (cf.WorkerScriptResponse, error)
 	UpdateWorkerCronTriggers(ctx context.Context, rc *cf.ResourceContainer, params cf.UpdateWorkerCronTriggersParams) ([]cf.WorkerCronTrigger, error)
 	WriteWorkersKVEntries(ctx context.Context, rc *cf.ResourceContainer, params cf.WriteWorkersKVEntriesParams) (cf.Response, error)
-	CreateD1Database(ctx context.Context, rc *cf.ResourceContainer, params cf.CreateD1DatabaseParams) (cf.D1Database, error)
+	// Legacy D1 methods — retained for one release cycle to clean up orphaned D1 databases
+	// from pre-Analytics-Engine versions. Remove after next release.
 	DeleteD1Database(ctx context.Context, rc *cf.ResourceContainer, databaseID string) error
 	ListD1Databases(ctx context.Context, rc *cf.ResourceContainer, params cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error)
-	QueryD1Database(ctx context.Context, rc *cf.ResourceContainer, params cf.QueryD1DatabaseParams) ([]cf.D1Result, error)
 }
 
 type CloudflareAccountManager struct {
@@ -71,12 +82,14 @@ type CloudflareAccountManager struct {
 	logger                *log.Entry
 	hasIPRangeKV          bool
 	NamespaceID           string
-	DatabaseID            string
 	KVPairByDecisionValue map[string]cf.WorkersKVPair
 	ipRangeKVPair         cf.WorkersKVPair
 	ActionByIPRange       map[string]string
 	Worker                *cfg.CloudflareWorkerCreateParams
-	hasD1Access           bool
+	httpClient            *http.Client
+	lastMetricsPoll       time.Time
+	metricsMu             sync.Mutex
+	cumulativeMetrics     map[string]float64
 }
 
 // This function creates a new instance of the CloudflareAccountManager struct,
@@ -113,6 +126,12 @@ func NewCloudflareManager(ctx context.Context, accountCfg cfg.AccountConfig, wor
 		ipRangeKVPair:   cf.WorkersKVPair{Key: IpRangeKeyName, Value: "{}"},
 		ActionByIPRange: make(map[string]string),
 		Worker:          worker,
+		httpClient: &http.Client{
+			Transport: &CloudflareManagerHTTPTransport{accountName: accountCfg.Name},
+			Timeout:   30 * time.Second,
+		},
+		lastMetricsPoll:   time.Now().UTC().Add(-metricsPollLookback).Truncate(time.Second),
+		cumulativeMetrics: make(map[string]float64),
 	}, nil
 }
 
@@ -148,6 +167,83 @@ type ActionsForZone struct {
 	DefaultAction    string   `json:"default_action"`
 }
 
+// enableWorkerObservability PATCHes the script-settings API to enable Workers
+// Observability (logs + traces). This is a direct HTTP call because cloudflare-go
+// v0.116.0 does not expose the observability field.
+func (m *CloudflareAccountManager) enableWorkerObservability(scriptName string) error {
+	obsCfg := m.Worker.Observability
+	if obsCfg == nil {
+		return nil
+	}
+
+	enabled := true
+	if obsCfg.Enabled != nil {
+		enabled = *obsCfg.Enabled
+	}
+
+	samplingRate := 1.0
+	if obsCfg.HeadSamplingRate != nil {
+		samplingRate = *obsCfg.HeadSamplingRate
+	}
+
+	type tracesPayload struct {
+		Enabled          bool    `json:"enabled"`
+		HeadSamplingRate float64 `json:"head_sampling_rate"`
+	}
+	type obsPayload struct {
+		Enabled          bool          `json:"enabled"`
+		HeadSamplingRate float64       `json:"head_sampling_rate"`
+		Traces           tracesPayload `json:"traces"`
+	}
+
+	// Default traces to match top-level settings; override if explicitly configured
+	traces := tracesPayload{Enabled: enabled, HeadSamplingRate: samplingRate}
+	if obsCfg.Traces != nil {
+		if obsCfg.Traces.Enabled != nil {
+			traces.Enabled = *obsCfg.Traces.Enabled
+		}
+		if obsCfg.Traces.HeadSamplingRate != nil {
+			traces.HeadSamplingRate = *obsCfg.Traces.HeadSamplingRate
+		}
+	}
+
+	payload, err := json.Marshal(struct {
+		Observability obsPayload `json:"observability"`
+	}{Observability: obsPayload{
+		Enabled:          enabled,
+		HeadSamplingRate: samplingRate,
+		Traces:           traces,
+	}})
+	if err != nil {
+		return fmt.Errorf("failed to marshal observability payload: %w", err)
+	}
+
+	url := fmt.Sprintf("https://api.cloudflare.com/client/v4/accounts/%s/workers/scripts/%s/script-settings",
+		m.AccountCfg.ID, scriptName)
+
+	req, err := http.NewRequestWithContext(m.Ctx, http.MethodPatch, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create observability request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+m.AccountCfg.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("observability settings request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("observability settings HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	m.logger.Infof("Configured observability for %s (logs=%t/%.2f, traces=%t/%.2f)",
+		scriptName, enabled, samplingRate, traces.Enabled, traces.HeadSamplingRate)
+	return nil
+}
+
 // Creates a new Cloudflare Workers KV namespace, uploads a new worker script, and binds the worker to one or more routes for
 // each zone configuration in the account. The method also creates a JSON-encoded string of supported actions for each zone
 // and binds it to the worker.
@@ -164,35 +260,6 @@ func (m *CloudflareAccountManager) DeployInfra() error {
 	}
 	m.logger.Tracef("KVNS: %+v", kvNSResp)
 	m.NamespaceID = kvNSResp.Result.ID
-
-	//Create the database
-	m.logger.Info("Creating D1 Database for metrics")
-
-	databaseResp, err := m.api.CreateD1Database(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), cf.CreateD1DatabaseParams{
-		Name: m.Worker.D1DBName,
-	})
-
-	//This could probably be a check on a more specific error, but because metrics are not critical, we just log the error and continue
-	if err != nil {
-		m.logger.Warnf("Error while creating D1 DB: %s. Remediation component won't be able to send metrics to crowdsec. Make sure your token has the proper permissions.", err)
-		m.hasD1Access = false
-	} else {
-		m.hasD1Access = true
-	}
-
-	if m.hasD1Access {
-		m.DatabaseID = databaseResp.UUID
-
-		_, err = m.api.QueryD1Database(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), cf.QueryD1DatabaseParams{
-			DatabaseID: m.DatabaseID,
-			SQL:        sqlCreateTableStatement,
-			Parameters: []string{},
-		})
-
-		if err != nil {
-			return fmt.Errorf("error while creating D1 DB table, make sure your token has the proper permissions: %w", err)
-		}
-	}
 
 	var banTemplate []byte
 	if m.AccountCfg.BanTemplate != "" {
@@ -228,11 +295,18 @@ func (m *CloudflareAccountManager) DeployInfra() error {
 
 	m.logger.Infof("Creating worker %s", m.Worker.ScriptName)
 
-	worker, err := m.api.UploadWorker(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), m.Worker.CreateWorkerParams(workerScript, kvNSResp.Result.ID, varActionsForZoneByDomain, m.DatabaseID))
+	worker, err := m.api.UploadWorker(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), m.Worker.CreateWorkerParams(workerScript, kvNSResp.Result.ID, varActionsForZoneByDomain, m.AccountCfg.Name))
 	m.logger.Tracef("Worker: %+v", worker)
 
 	if err != nil {
 		return err
+	}
+
+	if err := m.enableWorkerObservability(m.Worker.ScriptName); err != nil {
+		// Observability is a developer-experience feature; a misconfiguration
+		// (rate-limit, wrong scope on the token) shouldn't fail the whole deploy
+		// after the worker is already live. Log and continue.
+		m.logger.Warnf("Could not enable observability for %s: %s — deploy will continue without it", m.Worker.ScriptName, err)
 	}
 
 	zg := errgroup.Group{}
@@ -271,7 +345,7 @@ func (m *CloudflareAccountManager) DeployDecisionsSyncWorker(crowdSecConfig cfg.
 
 	// Create bindings for the sync worker
 	bindings := map[string]cf.WorkerBinding{
-		m.Worker.KVNameSpaceName: cf.WorkerKvNamespaceBinding{NamespaceID: m.NamespaceID},
+		cfg.KVWorkerBindingName: cf.WorkerKvNamespaceBinding{NamespaceID: m.NamespaceID},
 		"LAPI_URL": cf.WorkerPlainTextBinding{
 			Text: crowdSecConfig.CrowdSecLAPIUrl,
 		},
@@ -324,6 +398,12 @@ func (m *CloudflareAccountManager) DeployDecisionsSyncWorker(crowdSecConfig cfg.
 		return fmt.Errorf("failed to upload decisions sync worker: %w", err)
 	}
 	m.logger.Tracef("Decisions sync worker: %+v", worker)
+
+	if err := m.enableWorkerObservability(m.Worker.DecisionsSyncScriptName); err != nil {
+		// See note above the bouncer-worker observability call: this is a
+		// non-fatal DX feature; log and continue.
+		m.logger.Warnf("Could not enable observability for %s: %s — deploy will continue without it", m.Worker.DecisionsSyncScriptName, err)
+	}
 
 	// Deploy cron trigger for the decisions sync worker
 	m.logger.Infof("Deploying cron trigger for decisions sync worker: %s", cronSchedule)
@@ -439,63 +519,136 @@ func (m *CloudflareAccountManager) cleanupWorkerScripts() error {
 	return nil
 }
 
-func (m *CloudflareAccountManager) cleanupKVNamespaces() error {
+// findBoundKVNamespaceIDs inspects this instance's worker scripts and returns
+// the set of KV namespace IDs bound under cfg.KVWorkerBindingName. Used to
+// positively identify which namespaces belong to this instance before
+// teardown — without it, two instances sharing a Cloudflare account with the
+// same kv_namespace_name would each delete the other's live KV on teardown.
+// Must be called BEFORE cleanupWorkerScripts; once the script is gone, the
+// binding lookup returns a NotFoundError.
+func (m *CloudflareAccountManager) findBoundKVNamespaceIDs() map[string]struct{} {
+	ids := map[string]struct{}{}
+	scriptNames := []string{m.Worker.ScriptName, m.Worker.DecisionsSyncScriptName}
+	for _, scriptName := range scriptNames {
+		if scriptName == "" {
+			continue
+		}
+		resp, err := m.api.ListWorkerBindings(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), cf.ListWorkerBindingsParams{
+			ScriptName: scriptName,
+		})
+		if err != nil {
+			var notFoundErr *cf.NotFoundError
+			if errors.As(err, &notFoundErr) {
+				m.logger.Debugf("Worker script %q not deployed; no bindings to inspect", scriptName)
+				continue
+			}
+			m.logger.Warnf("Could not list bindings for worker %q: %s — KV cleanup will fall back to title match for this script", scriptName, err)
+			continue
+		}
+		for _, b := range resp.BindingList {
+			if b.Name != cfg.KVWorkerBindingName {
+				continue
+			}
+			kvBinding, ok := b.Binding.(cf.WorkerKvNamespaceBinding)
+			if !ok || kvBinding.NamespaceID == "" {
+				continue
+			}
+			ids[kvBinding.NamespaceID] = struct{}{}
+		}
+	}
+	return ids
+}
+
+// cleanupKVNamespaces deletes the KV namespaces belonging to this instance.
+// boundIDs (from findBoundKVNamespaceIDs) is the authoritative source: when
+// non-empty, ONLY those exact namespace IDs are deleted, so two instances
+// sharing the same kv_namespace_name can safely tear down independently.
+// When empty (worker script never deployed, or binding lookup failed), this
+// falls back to title-match — and logs a warning enumerating exactly which
+// namespaces are about to be deleted, so an operator notices a collision.
+func (m *CloudflareAccountManager) cleanupKVNamespaces(boundIDs map[string]struct{}) error {
 	m.logger.Debugf("Listing worker KV Namespaces")
 	kvNamespaces, _, err := m.api.ListWorkersKVNamespaces(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), cf.ListWorkersKVNamespacesParams{})
 	if err != nil {
 		return err
 	}
 	m.logger.Tracef("kvNamespaces: %+v", kvNamespaces)
-	m.logger.Debugf("Done listing worker KV Namespaces")
 
-	for _, kvNamespace := range kvNamespaces {
-		if kvNamespace.Title == m.Worker.KVNameSpaceName {
-			m.logger.Debugf("Deleting worker KV Namespace with ID %s", kvNamespace.ID)
-			_, err := m.api.DeleteWorkersKVNamespace(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), kvNamespace.ID)
-			if err != nil {
+	if len(boundIDs) > 0 {
+		for _, kv := range kvNamespaces {
+			if _, attributed := boundIDs[kv.ID]; !attributed {
+				continue
+			}
+			m.logger.Infof("Deleting KV namespace %q (id: %s, attributed via worker binding)", kv.Title, kv.ID)
+			if _, err := m.api.DeleteWorkersKVNamespace(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), kv.ID); err != nil {
 				return err
 			}
-			m.logger.Debugf("Done deleting worker KV Namespace with ID %s", kvNamespace.ID)
+		}
+		return nil
+	}
+
+	// Title-match fallback: collisions with another instance sharing the same
+	// kv_namespace_name are catastrophic (cross-instance KV wipe), so log
+	// loudly before deleting.
+	var titleMatches []cf.WorkersKVNamespace
+	for _, kv := range kvNamespaces {
+		if kv.Title == m.Worker.KVNameSpaceName {
+			titleMatches = append(titleMatches, kv)
+		}
+	}
+	if len(titleMatches) == 0 {
+		return nil
+	}
+	matchIDs := make([]string, 0, len(titleMatches))
+	for _, kv := range titleMatches {
+		matchIDs = append(matchIDs, kv.ID)
+	}
+	m.logger.Warnf(
+		"No worker bindings available to attribute KV namespace ownership; falling back to title match. "+
+			"About to delete %d namespace(s) titled %q: %v. "+
+			"If another bouncer instance shares this account, ensure its kv_namespace_name is unique.",
+		len(titleMatches), m.Worker.KVNameSpaceName, matchIDs)
+	for _, kv := range titleMatches {
+		m.logger.Infof("Deleting KV namespace %q (id: %s, attributed via title match)", kv.Title, kv.ID)
+		if _, err := m.api.DeleteWorkersKVNamespace(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), kv.ID); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-func (m *CloudflareAccountManager) cleanupD1Databases(start bool) error {
-	if !m.hasD1Access && !start {
-		return nil
-	}
-
-	m.logger.Debugf("Listing D1 DBs")
+// cleanupLegacyD1Databases removes D1 databases from pre-Analytics-Engine versions.
+// This is a one-release migration shim — remove after the next release.
+func (m *CloudflareAccountManager) cleanupLegacyD1Databases() {
+	m.logger.Debug("Checking for legacy D1 databases to clean up")
 	dbs, _, err := m.api.ListD1Databases(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), cf.ListD1DatabasesParams{})
-
 	if err != nil {
-		if !start {
-			return fmt.Errorf("error while listing D1 DBs, make sure your token has the proper permissions: %w", err)
-		}
-		dbs = []cf.D1Database{}
+		m.logger.Debugf("Could not list D1 databases (token may lack D1:Edit scope): %s", err)
+		return
 	}
 
-	m.logger.Tracef("dbs: %+v", dbs)
-
+	legacyName := "CROWDSECCFBOUNCERDB"
 	for _, db := range dbs {
-		m.logger.Debugf("Checking D1 DB %s vs %s", db.Name, m.Worker.D1DBName)
-		if db.Name == m.Worker.D1DBName {
-			m.logger.Debugf("Deleting D1 DB %s", db.UUID)
-			err = m.api.DeleteD1Database(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), db.UUID)
-			if err != nil {
-				return fmt.Errorf("error while deleting D1 DB %s, make sure your token has the proper permissions: %w", db.UUID, err)
+		if db.Name == legacyName {
+			m.logger.Infof("Deleting legacy D1 database %s (%s)", db.Name, db.UUID)
+			if err := m.api.DeleteD1Database(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), db.UUID); err != nil {
+				m.logger.Warnf("Failed to delete legacy D1 database %s: %s (delete manually via Cloudflare dashboard)", db.UUID, err)
+			} else {
+				m.logger.Infof("Deleted legacy D1 database %s", db.UUID)
 			}
-			m.logger.Debugf("Deleted D1 DB %s", db.UUID)
 		}
 	}
-	return nil
 }
 
 // This function checks and destroys the cloudflare infrastructure which could have been deployed by the worker in past.
 // It checks this, by matching the names of the KV namespaces, worker scripts, worker routes and turnstile widgets with the names used by the worker.
 func (m *CloudflareAccountManager) CleanUpExistingWorkers(start bool) error {
 	m.logger.Infof("Cleaning up existing workers")
+
+	// Capture KV namespace IDs from the live worker bindings BEFORE deleting
+	// the worker scripts — once the script is gone, the binding lookup 404s
+	// and cleanupKVNamespaces falls back to title-match (cross-instance risk).
+	boundKVIDs := m.findBoundKVNamespaceIDs()
 
 	if err := m.cleanupTurnstileWidgets(); err != nil {
 		return err
@@ -509,12 +662,14 @@ func (m *CloudflareAccountManager) CleanUpExistingWorkers(start bool) error {
 		return err
 	}
 
-	if err := m.cleanupKVNamespaces(); err != nil {
+	if err := m.cleanupKVNamespaces(boundKVIDs); err != nil {
 		return err
 	}
 
-	if err := m.cleanupD1Databases(start); err != nil {
-		return err
+	// Migration shim: clean up D1 databases from pre-Analytics-Engine versions.
+	// Remove this block after one release cycle.
+	if start {
+		m.cleanupLegacyD1Databases()
 	}
 
 	m.logger.Info("Done cleaning up existing workers")
@@ -837,66 +992,148 @@ func (m *CloudflareAccountManager) HandleTurnstile() error {
 	return g.Wait()
 }
 
-func (m *CloudflareAccountManager) UpdateMetrics() error {
-	m.logger.Debug("Getting metrics")
-	if !m.hasD1Access {
-		m.logger.Debug("No D1 access, skipping metrics update")
-		return nil
-	}
-	resp, err := m.api.QueryD1Database(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), cf.QueryD1DatabaseParams{
-		DatabaseID: m.DatabaseID,
-		SQL:        "SELECT * FROM metrics",
-		Parameters: []string{},
-	})
-	if err != nil {
-		return err
-	}
-	m.logger.Tracef("resp: %+v", resp)
+// aeQueryMeta describes a column returned by the Analytics Engine SQL API.
+type aeQueryMeta struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
 
-	for _, r := range resp {
-		if r.Success == nil || !*r.Success {
-			m.logger.Warnf("Query failed: %+v", r)
+// aeQueryResult represents the JSON response from the Analytics Engine SQL API.
+type aeQueryResult struct {
+	Meta []aeQueryMeta    `json:"meta"`
+	Data []map[string]any `json:"data"`
+	Rows int              `json:"rows"`
+}
+
+func (m *CloudflareAccountManager) queryAnalyticsEngine(query string) (*aeQueryResult, error) {
+	url := fmt.Sprintf("https://api.cloudflare.com/client/v4/accounts/%s/analytics_engine/sql", m.AccountCfg.ID)
+
+	req, err := http.NewRequestWithContext(m.Ctx, http.MethodPost, url, strings.NewReader(query))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AE request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+m.AccountCfg.Token)
+	req.Header.Set("Content-Type", "text/plain")
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("AE query failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read AE response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("AE query returned HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result aeQueryResult
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse AE response: %w", err)
+	}
+	return &result, nil
+}
+
+func (m *CloudflareAccountManager) UpdateMetrics() error {
+	m.metricsMu.Lock()
+	defer m.metricsMu.Unlock()
+
+	m.logger.Debug("Getting metrics from Analytics Engine")
+
+	// AE only supports second-precision toDateTime. Query the half-open window
+	// [lastMetricsPoll, windowEnd) and advance the cursor to windowEnd so every
+	// second is counted exactly once. windowEnd lags wall-clock by
+	// aeIngestionLag so we don't read across the AE indexing boundary — rows
+	// arriving late within that window land in the next poll instead of being
+	// stepped over and lost forever.
+	windowEnd := time.Now().UTC().Add(-aeIngestionLag).Truncate(time.Second)
+
+	// AE field mapping (must match writeMetricEvent in worker.js):
+	//   blob1 = metric_name, blob2 = ip_type, blob3 = origin, blob4 = remediation_type
+	//   double1 = count (1), double2 = latency_ms
+	// AnalyticsDataset and AccountCfg.Name are allowlist-validated at config load.
+	query := fmt.Sprintf(`SELECT
+		blob1 AS metric_name,
+		blob2 AS ip_type,
+		blob3 AS origin,
+		blob4 AS remediation_type,
+		SUM(_sample_interval * double1) AS val,
+		AVG(double2) AS avg_latency_ms
+	FROM %s
+	WHERE timestamp >= toDateTime('%s')
+		AND timestamp < toDateTime('%s')
+		AND index1 = '%s'
+	GROUP BY metric_name, ip_type, origin, remediation_type
+	FORMAT JSON`,
+		m.Worker.AnalyticsDataset,
+		m.lastMetricsPoll.Format("2006-01-02 15:04:05"),
+		windowEnd.Format("2006-01-02 15:04:05"),
+		m.AccountCfg.Name,
+	)
+
+	result, err := m.queryAnalyticsEngine(query)
+	if err != nil {
+		return fmt.Errorf("unable to query Analytics Engine: %w", err)
+	}
+	m.lastMetricsPoll = windowEnd
+	m.logger.Tracef("AE result: %+v", result)
+
+	for _, row := range result.Data {
+		metricName, ok := row["metric_name"].(string)
+		if !ok {
+			m.logger.Warnf("Invalid metric_name type in AE response: %T", row["metric_name"])
 			continue
 		}
-		for _, data := range r.Results {
-			switch data["metric_name"] {
-			case "processed":
-				val, ok := data["val"].(float64)
-				if !ok {
-					m.logger.Warnf("Invalid value for processed metric: %+v", data)
-					continue
-				}
-				ipType, ok := data["ip_type"].(string)
-				if !ok {
-					m.logger.Warnf("Invalid value for ip_type: %+v", data)
-					continue
-				}
-				metrics.TotalProcessedRequests.With(prometheus.Labels{"ip_type": ipType, "account": m.AccountCfg.Name}).Set(val)
-			case "dropped":
-				val, ok := data["val"].(float64)
-				if !ok {
-					m.logger.Warnf("Invalid value for dropped metric: %+v", data)
-					continue
-				}
-				origin, ok := data["origin"].(string)
-				if !ok {
-					m.logger.Warnf("Invalid value for origin: %+v", data)
-					continue
-				}
-				ipType, ok := data["ip_type"].(string)
-				if !ok {
-					m.logger.Warnf("Invalid value for ip_type: %+v", data)
-					continue
-				}
-				remediation, ok := data["remediation_type"].(string)
-				if !ok {
-					m.logger.Warnf("Invalid value for remediation: %+v", data)
-					continue
-				}
-				metrics.TotalBlockedRequests.With(prometheus.Labels{"origin": origin, "remediation": remediation, "ip_type": ipType, "account": m.AccountCfg.Name}).Set(val)
-			default:
-				m.logger.Warnf("Unknown metric: %+v", data)
-			}
+		val, ok := row["val"].(float64)
+		if !ok {
+			m.logger.Warnf("Invalid val type in AE response for metric %s: %T", metricName, row["val"])
+			continue
+		}
+		var ipType, origin, remediation string
+		if v, ok := row["ip_type"].(string); ok {
+			ipType = v
+		}
+		if v, ok := row["origin"].(string); ok {
+			origin = v
+		}
+		if v, ok := row["remediation_type"].(string); ok {
+			remediation = v
+		}
+
+		switch metricName {
+		case "processed":
+			key := "processed:" + ipType + ":" + m.AccountCfg.Name
+			m.cumulativeMetrics[key] += val
+			metrics.TotalProcessedRequests.With(prometheus.Labels{
+				"ip_type": ipType, "account": m.AccountCfg.Name,
+			}).Set(m.cumulativeMetrics[key])
+		case "dropped":
+			key := "dropped:" + origin + ":" + remediation + ":" + ipType + ":" + m.AccountCfg.Name
+			m.cumulativeMetrics[key] += val
+			metrics.TotalBlockedRequests.With(prometheus.Labels{
+				"origin": origin, "remediation": remediation,
+				"ip_type": ipType, "account": m.AccountCfg.Name,
+			}).Set(m.cumulativeMetrics[key])
+		case "error":
+			key := "error:" + ipType + ":" + m.AccountCfg.Name
+			m.cumulativeMetrics[key] += val
+			metrics.TotalErrors.With(prometheus.Labels{
+				"ip_type": ipType, "account": m.AccountCfg.Name,
+			}).Set(m.cumulativeMetrics[key])
+		default:
+			m.logger.Warnf("Unknown metric from AE: %s", metricName)
+		}
+
+		if latency, ok := row["avg_latency_ms"].(float64); ok {
+			metrics.AverageLatencyMs.With(prometheus.Labels{
+				"account":     m.AccountCfg.Name,
+				"metric_name": metricName,
+				"ip_type":     ipType,
+				"remediation": remediation,
+			}).Set(latency)
 		}
 	}
 

--- a/pkg/cloudflare/cloudflare.go
+++ b/pkg/cloudflare/cloudflare.go
@@ -69,10 +69,6 @@ type cloudflareAPI interface {
 	UploadWorker(ctx context.Context, rc *cf.ResourceContainer, params cf.CreateWorkerParams) (cf.WorkerScriptResponse, error)
 	UpdateWorkerCronTriggers(ctx context.Context, rc *cf.ResourceContainer, params cf.UpdateWorkerCronTriggersParams) ([]cf.WorkerCronTrigger, error)
 	WriteWorkersKVEntries(ctx context.Context, rc *cf.ResourceContainer, params cf.WriteWorkersKVEntriesParams) (cf.Response, error)
-	// Legacy D1 methods — retained for one release cycle to clean up orphaned D1 databases
-	// from pre-Analytics-Engine versions. Remove after next release.
-	DeleteD1Database(ctx context.Context, rc *cf.ResourceContainer, databaseID string) error
-	ListD1Databases(ctx context.Context, rc *cf.ResourceContainer, params cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error)
 }
 
 type CloudflareAccountManager struct {
@@ -617,32 +613,9 @@ func (m *CloudflareAccountManager) cleanupKVNamespaces(boundIDs map[string]struc
 	return nil
 }
 
-// cleanupLegacyD1Databases removes D1 databases from pre-Analytics-Engine versions.
-// This is a one-release migration shim — remove after the next release.
-func (m *CloudflareAccountManager) cleanupLegacyD1Databases() {
-	m.logger.Debug("Checking for legacy D1 databases to clean up")
-	dbs, _, err := m.api.ListD1Databases(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), cf.ListD1DatabasesParams{})
-	if err != nil {
-		m.logger.Debugf("Could not list D1 databases (token may lack D1:Edit scope): %s", err)
-		return
-	}
-
-	legacyName := "CROWDSECCFBOUNCERDB"
-	for _, db := range dbs {
-		if db.Name == legacyName {
-			m.logger.Infof("Deleting legacy D1 database %s (%s)", db.Name, db.UUID)
-			if err := m.api.DeleteD1Database(m.Ctx, cf.AccountIdentifier(m.AccountCfg.ID), db.UUID); err != nil {
-				m.logger.Warnf("Failed to delete legacy D1 database %s: %s (delete manually via Cloudflare dashboard)", db.UUID, err)
-			} else {
-				m.logger.Infof("Deleted legacy D1 database %s", db.UUID)
-			}
-		}
-	}
-}
-
 // This function checks and destroys the cloudflare infrastructure which could have been deployed by the worker in past.
 // It checks this, by matching the names of the KV namespaces, worker scripts, worker routes and turnstile widgets with the names used by the worker.
-func (m *CloudflareAccountManager) CleanUpExistingWorkers(start bool) error {
+func (m *CloudflareAccountManager) CleanUpExistingWorkers() error {
 	m.logger.Infof("Cleaning up existing workers")
 
 	// Capture KV namespace IDs from the live worker bindings BEFORE deleting
@@ -664,12 +637,6 @@ func (m *CloudflareAccountManager) CleanUpExistingWorkers(start bool) error {
 
 	if err := m.cleanupKVNamespaces(boundKVIDs); err != nil {
 		return err
-	}
-
-	// Migration shim: clean up D1 databases from pre-Analytics-Engine versions.
-	// Remove this block after one release cycle.
-	if start {
-		m.cleanupLegacyD1Databases()
 	}
 
 	m.logger.Info("Done cleaning up existing workers")

--- a/pkg/cloudflare/cloudflare_test.go
+++ b/pkg/cloudflare/cloudflare_test.go
@@ -116,10 +116,6 @@ func resetMetrics() {
 // --- Mock cloudflareAPI ---
 
 type mockCFAPI struct {
-	listD1DatabasesFn  func(context.Context, *cf.ResourceContainer, cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error)
-	deleteD1DatabaseFn func(context.Context, *cf.ResourceContainer, string) error
-	deleteD1Calls      []string
-
 	// KV cleanup hooks (A-2 multi-instance teardown safety)
 	listWorkerBindingsFn       func(context.Context, *cf.ResourceContainer, cf.ListWorkerBindingsParams) (cf.WorkerBindingListResponse, error)
 	listWorkersKVNamespacesFn  func(context.Context, *cf.ResourceContainer, cf.ListWorkersKVNamespacesParams) ([]cf.WorkersKVNamespace, *cf.ResultInfo, error)
@@ -197,20 +193,6 @@ func (*mockCFAPI) UpdateWorkerCronTriggers(_ context.Context, _ *cf.ResourceCont
 func (*mockCFAPI) WriteWorkersKVEntries(_ context.Context, _ *cf.ResourceContainer, _ cf.WriteWorkersKVEntriesParams) (cf.Response, error) {
 	return cf.Response{}, nil
 }
-func (m *mockCFAPI) ListD1Databases(ctx context.Context, rc *cf.ResourceContainer, params cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error) {
-	if m.listD1DatabasesFn != nil {
-		return m.listD1DatabasesFn(ctx, rc, params)
-	}
-	return nil, nil, nil
-}
-func (m *mockCFAPI) DeleteD1Database(ctx context.Context, rc *cf.ResourceContainer, databaseID string) error {
-	m.deleteD1Calls = append(m.deleteD1Calls, databaseID)
-	if m.deleteD1DatabaseFn != nil {
-		return m.deleteD1DatabaseFn(ctx, rc, databaseID)
-	}
-	return nil
-}
-
 // ============================================================
 // Group 1: queryAnalyticsEngine
 // ============================================================
@@ -584,90 +566,7 @@ func TestUpdateMetrics_MissingLatency_NoError(t *testing.T) {
 }
 
 // ============================================================
-// Group 3: cleanupLegacyD1Databases
-// ============================================================
-
-func TestCleanupLegacyD1_FindsAndDeletes(t *testing.T) {
-	mock := &mockCFAPI{
-		listD1DatabasesFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error) {
-			return []cf.D1Database{
-				{UUID: "db-legacy", Name: "CROWDSECCFBOUNCERDB"},
-				{UUID: "db-other", Name: "unrelated-database"},
-			}, nil, nil
-		},
-	}
-
-	m := newTestManager()
-	m.api = mock
-	m.cleanupLegacyD1Databases()
-
-	if len(mock.deleteD1Calls) != 1 {
-		t.Fatalf("expected 1 delete call, got %d", len(mock.deleteD1Calls))
-	}
-	if mock.deleteD1Calls[0] != "db-legacy" {
-		t.Errorf("deleted %q, want db-legacy", mock.deleteD1Calls[0])
-	}
-}
-
-func TestCleanupLegacyD1_NoneFound(t *testing.T) {
-	mock := &mockCFAPI{
-		listD1DatabasesFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error) {
-			return []cf.D1Database{
-				{UUID: "db-other", Name: "unrelated-database"},
-			}, nil, nil
-		},
-	}
-
-	m := newTestManager()
-	m.api = mock
-	m.cleanupLegacyD1Databases()
-
-	if len(mock.deleteD1Calls) != 0 {
-		t.Errorf("expected 0 delete calls, got %d", len(mock.deleteD1Calls))
-	}
-}
-
-func TestCleanupLegacyD1_ListError(t *testing.T) {
-	mock := &mockCFAPI{
-		listD1DatabasesFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error) {
-			return nil, nil, errors.New("permission denied")
-		},
-	}
-
-	m := newTestManager()
-	m.api = mock
-	// Should not panic or propagate error
-	m.cleanupLegacyD1Databases()
-
-	if len(mock.deleteD1Calls) != 0 {
-		t.Error("should not attempt deletes after list error")
-	}
-}
-
-func TestCleanupLegacyD1_DeleteError(t *testing.T) {
-	mock := &mockCFAPI{
-		listD1DatabasesFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error) {
-			return []cf.D1Database{
-				{UUID: "db-legacy", Name: "CROWDSECCFBOUNCERDB"},
-			}, nil, nil
-		},
-		deleteD1DatabaseFn: func(_ context.Context, _ *cf.ResourceContainer, _ string) error {
-			return errors.New("delete failed")
-		},
-	}
-
-	m := newTestManager()
-	m.api = mock
-	// Should warn but not panic
-	m.cleanupLegacyD1Databases()
-
-	if len(mock.deleteD1Calls) != 1 {
-		t.Error("should have attempted delete despite failure")
-	}
-}
-
-// ============================================================
-// Group 4: cleanupKVNamespaces — multi-instance teardown safety
+// Group 3: cleanupKVNamespaces — multi-instance teardown safety
 // ============================================================
 
 // When two bouncer instances share a Cloudflare account with the same

--- a/pkg/cloudflare/cloudflare_test.go
+++ b/pkg/cloudflare/cloudflare_test.go
@@ -1,0 +1,1067 @@
+package cf
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	cf "github.com/cloudflare/cloudflare-go"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/crowdsecurity/crowdsec-cloudflare-worker-bouncer/pkg/cfg"
+	"github.com/crowdsecurity/crowdsec-cloudflare-worker-bouncer/pkg/metrics"
+)
+
+// --- Test Infrastructure ---
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func gaugeValue(g prometheus.Gauge) float64 {
+	m := &dto.Metric{}
+	if err := g.Write(m); err != nil {
+		panic("failed to read gauge: " + err.Error())
+	}
+	return m.GetGauge().GetValue()
+}
+
+func makeAEResponseClient(data []map[string]any) *http.Client {
+	result := aeQueryResult{Data: data, Rows: len(data)}
+	respBody, err := json.Marshal(&result)
+	if err != nil {
+		panic("makeAEResponseClient: " + err.Error())
+	}
+	body := string(respBody)
+	return &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			_, _ = io.ReadAll(r.Body)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+}
+
+func makeAEErrorClient(statusCode int, body string) *http.Client {
+	return &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			_, _ = io.ReadAll(r.Body)
+			return &http.Response{
+				StatusCode: statusCode,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+}
+
+type capturedRequest struct {
+	Request *http.Request
+	Body    string
+}
+
+func captureRequestClient(responseBody string) (*http.Client, *capturedRequest) {
+	captured := &capturedRequest{}
+	client := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			captured.Request = r
+			body, _ := io.ReadAll(r.Body)
+			captured.Body = string(body)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(responseBody)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+	return client, captured
+}
+
+func newTestManager() *CloudflareAccountManager {
+	return &CloudflareAccountManager{
+		AccountCfg: cfg.AccountConfig{
+			ID:    "test-account-id",
+			Token: "test-token",
+			Name:  "test-account",
+		},
+		Ctx:    context.Background(),
+		logger: log.WithFields(log.Fields{"account": "test-account"}),
+		Worker: &cfg.CloudflareWorkerCreateParams{
+			AnalyticsDataset: "test_dataset",
+		},
+		httpClient:        &http.Client{},
+		lastMetricsPoll:   time.Now().UTC().Add(-metricsPollLookback),
+		cumulativeMetrics: make(map[string]float64),
+	}
+}
+
+func resetMetrics() {
+	metrics.TotalProcessedRequests.Reset()
+	metrics.TotalBlockedRequests.Reset()
+	metrics.AverageLatencyMs.Reset()
+	metrics.TotalErrors.Reset()
+}
+
+// --- Mock cloudflareAPI ---
+
+type mockCFAPI struct {
+	listD1DatabasesFn  func(context.Context, *cf.ResourceContainer, cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error)
+	deleteD1DatabaseFn func(context.Context, *cf.ResourceContainer, string) error
+	deleteD1Calls      []string
+
+	// KV cleanup hooks (A-2 multi-instance teardown safety)
+	listWorkerBindingsFn       func(context.Context, *cf.ResourceContainer, cf.ListWorkerBindingsParams) (cf.WorkerBindingListResponse, error)
+	listWorkersKVNamespacesFn  func(context.Context, *cf.ResourceContainer, cf.ListWorkersKVNamespacesParams) ([]cf.WorkersKVNamespace, *cf.ResultInfo, error)
+	deleteWorkersKVNamespaceFn func(context.Context, *cf.ResourceContainer, string) (cf.Response, error)
+	deleteKVCalls              []string
+}
+
+func (*mockCFAPI) Account(_ context.Context, _ string) (cf.Account, cf.ResultInfo, error) {
+	return cf.Account{}, cf.ResultInfo{}, nil
+}
+func (*mockCFAPI) CreateTurnstileWidget(_ context.Context, _ *cf.ResourceContainer, _ cf.CreateTurnstileWidgetParams) (cf.TurnstileWidget, error) {
+	return cf.TurnstileWidget{}, nil
+}
+func (*mockCFAPI) CreateWorkerRoute(_ context.Context, _ *cf.ResourceContainer, _ cf.CreateWorkerRouteParams) (cf.WorkerRouteResponse, error) {
+	return cf.WorkerRouteResponse{}, nil
+}
+func (*mockCFAPI) CreateWorkersKVNamespace(_ context.Context, _ *cf.ResourceContainer, _ cf.CreateWorkersKVNamespaceParams) (cf.WorkersKVNamespaceResponse, error) {
+	return cf.WorkersKVNamespaceResponse{}, nil
+}
+func (*mockCFAPI) DeleteTurnstileWidget(_ context.Context, _ *cf.ResourceContainer, _ string) error {
+	return nil
+}
+func (*mockCFAPI) DeleteWorker(_ context.Context, _ *cf.ResourceContainer, _ cf.DeleteWorkerParams) error {
+	return nil
+}
+func (*mockCFAPI) DeleteWorkerRoute(_ context.Context, _ *cf.ResourceContainer, _ string) (cf.WorkerRouteResponse, error) {
+	return cf.WorkerRouteResponse{}, nil
+}
+func (*mockCFAPI) DeleteWorkersKVEntries(_ context.Context, _ *cf.ResourceContainer, _ cf.DeleteWorkersKVEntriesParams) (cf.Response, error) {
+	return cf.Response{}, nil
+}
+func (m *mockCFAPI) DeleteWorkersKVNamespace(ctx context.Context, rc *cf.ResourceContainer, namespaceID string) (cf.Response, error) {
+	m.deleteKVCalls = append(m.deleteKVCalls, namespaceID)
+	if m.deleteWorkersKVNamespaceFn != nil {
+		return m.deleteWorkersKVNamespaceFn(ctx, rc, namespaceID)
+	}
+	return cf.Response{}, nil
+}
+func (*mockCFAPI) ListTurnstileWidgets(_ context.Context, _ *cf.ResourceContainer, _ cf.ListTurnstileWidgetParams) ([]cf.TurnstileWidget, *cf.ResultInfo, error) {
+	return nil, nil, nil
+}
+func (*mockCFAPI) ListWorkerRoutes(_ context.Context, _ *cf.ResourceContainer, _ cf.ListWorkerRoutesParams) (cf.WorkerRoutesResponse, error) {
+	return cf.WorkerRoutesResponse{}, nil
+}
+func (m *mockCFAPI) ListWorkerBindings(ctx context.Context, rc *cf.ResourceContainer, params cf.ListWorkerBindingsParams) (cf.WorkerBindingListResponse, error) {
+	if m.listWorkerBindingsFn != nil {
+		return m.listWorkerBindingsFn(ctx, rc, params)
+	}
+	return cf.WorkerBindingListResponse{}, nil
+}
+func (m *mockCFAPI) ListWorkersKVNamespaces(ctx context.Context, rc *cf.ResourceContainer, params cf.ListWorkersKVNamespacesParams) ([]cf.WorkersKVNamespace, *cf.ResultInfo, error) {
+	if m.listWorkersKVNamespacesFn != nil {
+		return m.listWorkersKVNamespacesFn(ctx, rc, params)
+	}
+	return nil, nil, nil
+}
+func (*mockCFAPI) ListWorkersSecrets(_ context.Context, _ *cf.ResourceContainer, _ cf.ListWorkersSecretsParams) (cf.WorkersListSecretsResponse, error) {
+	return cf.WorkersListSecretsResponse{}, nil
+}
+func (*mockCFAPI) ListZones(_ context.Context, _ ...string) ([]cf.Zone, error) {
+	return nil, nil
+}
+func (*mockCFAPI) RotateTurnstileWidget(_ context.Context, _ *cf.ResourceContainer, _ cf.RotateTurnstileWidgetParams) (cf.TurnstileWidget, error) {
+	return cf.TurnstileWidget{}, nil
+}
+func (*mockCFAPI) SetWorkersSecret(_ context.Context, _ *cf.ResourceContainer, _ cf.SetWorkersSecretParams) (cf.WorkersPutSecretResponse, error) {
+	return cf.WorkersPutSecretResponse{}, nil
+}
+func (*mockCFAPI) UploadWorker(_ context.Context, _ *cf.ResourceContainer, _ cf.CreateWorkerParams) (cf.WorkerScriptResponse, error) {
+	return cf.WorkerScriptResponse{}, nil
+}
+func (*mockCFAPI) UpdateWorkerCronTriggers(_ context.Context, _ *cf.ResourceContainer, _ cf.UpdateWorkerCronTriggersParams) ([]cf.WorkerCronTrigger, error) {
+	return nil, nil
+}
+func (*mockCFAPI) WriteWorkersKVEntries(_ context.Context, _ *cf.ResourceContainer, _ cf.WriteWorkersKVEntriesParams) (cf.Response, error) {
+	return cf.Response{}, nil
+}
+func (m *mockCFAPI) ListD1Databases(ctx context.Context, rc *cf.ResourceContainer, params cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error) {
+	if m.listD1DatabasesFn != nil {
+		return m.listD1DatabasesFn(ctx, rc, params)
+	}
+	return nil, nil, nil
+}
+func (m *mockCFAPI) DeleteD1Database(ctx context.Context, rc *cf.ResourceContainer, databaseID string) error {
+	m.deleteD1Calls = append(m.deleteD1Calls, databaseID)
+	if m.deleteD1DatabaseFn != nil {
+		return m.deleteD1DatabaseFn(ctx, rc, databaseID)
+	}
+	return nil
+}
+
+// ============================================================
+// Group 1: queryAnalyticsEngine
+// ============================================================
+
+func TestQueryAnalyticsEngine_SendsRawSQL(t *testing.T) {
+	emptyResponse := `{"meta":[],"data":[],"rows":0}`
+	client, captured := captureRequestClient(emptyResponse)
+
+	m := newTestManager()
+	m.httpClient = client
+
+	query := "SELECT blob1 FROM test_dataset FORMAT JSON"
+	_, err := m.queryAnalyticsEngine(query)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if captured.Request.Header.Get("Content-Type") != "text/plain" {
+		t.Errorf("Content-Type = %q, want text/plain", captured.Request.Header.Get("Content-Type"))
+	}
+	if captured.Request.Header.Get("Authorization") != "Bearer test-token" {
+		t.Errorf("Authorization = %q, want Bearer test-token", captured.Request.Header.Get("Authorization"))
+	}
+	if captured.Body != query {
+		t.Errorf("body = %q, want raw SQL %q", captured.Body, query)
+	}
+	wantURL := "https://api.cloudflare.com/client/v4/accounts/test-account-id/analytics_engine/sql"
+	if captured.Request.URL.String() != wantURL {
+		t.Errorf("URL = %q, want %q", captured.Request.URL.String(), wantURL)
+	}
+}
+
+func TestQueryAnalyticsEngine_HTTPError(t *testing.T) {
+	m := newTestManager()
+	m.httpClient = makeAEErrorClient(403, "Forbidden: invalid token")
+
+	_, err := m.queryAnalyticsEngine("SELECT 1")
+	if err == nil {
+		t.Fatal("expected error for HTTP 403")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error should contain status code 403, got: %v", err)
+	}
+}
+
+func TestQueryAnalyticsEngine_InvalidJSON(t *testing.T) {
+	m := newTestManager()
+	m.httpClient = &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			_, _ = io.ReadAll(r.Body)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("not json")),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	_, err := m.queryAnalyticsEngine("SELECT 1")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "parse") {
+		t.Errorf("error should mention parsing, got: %v", err)
+	}
+}
+
+func TestQueryAnalyticsEngine_Success(t *testing.T) {
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "processed", "ip_type": "ipv4", "val": 42.0},
+	})
+
+	result, err := m.queryAnalyticsEngine("SELECT 1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Rows != 1 {
+		t.Errorf("Rows = %d, want 1", result.Rows)
+	}
+	if len(result.Data) != 1 {
+		t.Fatalf("Data length = %d, want 1", len(result.Data))
+	}
+	if result.Data[0]["metric_name"] != "processed" {
+		t.Errorf("metric_name = %v, want processed", result.Data[0]["metric_name"])
+	}
+}
+
+// ============================================================
+// Group 2: UpdateMetrics
+// ============================================================
+
+func TestUpdateMetrics_HappyPath(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "processed", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 100.0, "avg_latency_ms": 12.5},
+		{"metric_name": "dropped", "ip_type": "ipv6", "origin": "crowdsec", "remediation_type": "ban", "val": 7.0, "avg_latency_ms": 45.0},
+	})
+
+	if err := m.UpdateMetrics(); err != nil {
+		t.Fatalf("UpdateMetrics failed: %v", err)
+	}
+
+	processed := gaugeValue(metrics.TotalProcessedRequests.With(prometheus.Labels{
+		"ip_type": "ipv4", "account": "test-account",
+	}))
+	if processed != 100.0 {
+		t.Errorf("processed = %f, want 100", processed)
+	}
+
+	dropped := gaugeValue(metrics.TotalBlockedRequests.With(prometheus.Labels{
+		"origin": "crowdsec", "remediation": "ban", "ip_type": "ipv6", "account": "test-account",
+	}))
+	if dropped != 7.0 {
+		t.Errorf("dropped = %f, want 7", dropped)
+	}
+
+	// Each grouped row gets its own label series — no last-row-wins.
+	processedLatency := gaugeValue(metrics.AverageLatencyMs.With(prometheus.Labels{
+		"account": "test-account", "metric_name": "processed", "ip_type": "ipv4", "remediation": "",
+	}))
+	if processedLatency != 12.5 {
+		t.Errorf("processed avg_latency_ms = %f, want 12.5", processedLatency)
+	}
+	droppedLatency := gaugeValue(metrics.AverageLatencyMs.With(prometheus.Labels{
+		"account": "test-account", "metric_name": "dropped", "ip_type": "ipv6", "remediation": "ban",
+	}))
+	if droppedLatency != 45.0 {
+		t.Errorf("dropped avg_latency_ms = %f, want 45", droppedLatency)
+	}
+}
+
+func TestUpdateMetrics_CumulativeTracking(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+
+	// First call: 10 processed
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "processed", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 10.0},
+		{"metric_name": "dropped", "ip_type": "ipv4", "origin": "crowdsec", "remediation_type": "ban", "val": 3.0},
+	})
+	if err := m.UpdateMetrics(); err != nil {
+		t.Fatalf("first UpdateMetrics failed: %v", err)
+	}
+
+	// Second call: 5 more processed
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "processed", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 5.0},
+		{"metric_name": "dropped", "ip_type": "ipv4", "origin": "crowdsec", "remediation_type": "ban", "val": 2.0},
+	})
+	if err := m.UpdateMetrics(); err != nil {
+		t.Fatalf("second UpdateMetrics failed: %v", err)
+	}
+
+	processed := gaugeValue(metrics.TotalProcessedRequests.With(prometheus.Labels{
+		"ip_type": "ipv4", "account": "test-account",
+	}))
+	if processed != 15.0 {
+		t.Errorf("processed = %f, want 15 (10+5)", processed)
+	}
+
+	dropped := gaugeValue(metrics.TotalBlockedRequests.With(prometheus.Labels{
+		"origin": "crowdsec", "remediation": "ban", "ip_type": "ipv4", "account": "test-account",
+	}))
+	if dropped != 5.0 {
+		t.Errorf("dropped = %f, want 5 (3+2)", dropped)
+	}
+}
+
+func TestUpdateMetrics_ConcurrentSafety(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "processed", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 1.0},
+	})
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			_ = m.UpdateMetrics()
+		}()
+	}
+	wg.Wait()
+
+	// Mutex serializes calls: each adds 1.0, total = 20.
+	// The -race flag validates no data races.
+	val := m.cumulativeMetrics["processed:ipv4:test-account"]
+	if val != float64(goroutines) {
+		t.Errorf("cumulative = %f, want %d", val, goroutines)
+	}
+}
+
+func TestUpdateMetrics_InvalidMetricName(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": 12345, "val": 1.0}, // metric_name is not a string
+	})
+
+	err := m.UpdateMetrics()
+	if err != nil {
+		t.Fatalf("should not return error for bad metric_name type: %v", err)
+	}
+}
+
+func TestUpdateMetrics_InvalidVal(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "processed", "ip_type": "ipv4", "val": "not-a-number"},
+	})
+
+	err := m.UpdateMetrics()
+	if err != nil {
+		t.Fatalf("should not return error for bad val type: %v", err)
+	}
+}
+
+func TestUpdateMetrics_UnknownMetric(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "unknown_metric", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 1.0},
+	})
+
+	err := m.UpdateMetrics()
+	if err != nil {
+		t.Fatalf("unknown metric should not cause error: %v", err)
+	}
+}
+
+func TestUpdateMetrics_ErrorMetric(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "error", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 3.0},
+	})
+
+	if err := m.UpdateMetrics(); err != nil {
+		t.Fatalf("UpdateMetrics failed: %v", err)
+	}
+
+	errs := gaugeValue(metrics.TotalErrors.With(prometheus.Labels{
+		"ip_type": "ipv4", "account": "test-account",
+	}))
+	if errs != 3.0 {
+		t.Errorf("errors = %f, want 3", errs)
+	}
+}
+
+func TestUpdateMetrics_EmptyResult(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	m.httpClient = makeAEResponseClient(nil)
+
+	err := m.UpdateMetrics()
+	if err != nil {
+		t.Fatalf("empty result should not cause error: %v", err)
+	}
+	if len(m.cumulativeMetrics) != 0 {
+		t.Errorf("cumulative should be empty, got %v", m.cumulativeMetrics)
+	}
+}
+
+func TestUpdateMetrics_QueryError(t *testing.T) {
+	m := newTestManager()
+	originalPoll := m.lastMetricsPoll
+	m.httpClient = makeAEErrorClient(500, "internal server error")
+
+	err := m.UpdateMetrics()
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+	if !m.lastMetricsPoll.Equal(originalPoll) {
+		t.Error("lastMetricsPoll should not advance on error")
+	}
+}
+
+func TestUpdateMetrics_AdvancesTimestamp(t *testing.T) {
+	m := newTestManager()
+	before := time.Now().UTC()
+	m.lastMetricsPoll = before.Add(-5 * time.Minute)
+	m.httpClient = makeAEResponseClient(nil)
+
+	if err := m.UpdateMetrics(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// windowEnd intentionally lags wall-clock by aeIngestionLag (10s) so the
+	// cursor doesn't read across the AE indexing boundary. Tolerate that lag
+	// plus a small fudge for second-precision truncation.
+	if !m.lastMetricsPoll.After(before.Add(-aeIngestionLag - 2*time.Second)) {
+		t.Errorf("lastMetricsPoll should be ~(now - aeIngestionLag), got %v", m.lastMetricsPoll)
+	}
+}
+
+func TestUpdateMetrics_QueryContainsTimestamp(t *testing.T) {
+	emptyResp := `{"meta":[],"data":[],"rows":0}`
+	client, captured := captureRequestClient(emptyResp)
+
+	// AE supports only second-precision toDateTime; the sub-second component
+	// of lastMetricsPoll is truncated in the lower bound.
+	pollTime := time.Date(2025, 6, 15, 14, 30, 0, 123000000, time.UTC)
+	m := newTestManager()
+	m.lastMetricsPoll = pollTime
+	m.httpClient = client
+
+	_ = m.UpdateMetrics()
+
+	if !strings.Contains(captured.Body, "timestamp >= toDateTime('2025-06-15 14:30:00')") {
+		t.Errorf("query should contain second-precision lower bound, got:\n%s", captured.Body)
+	}
+	if !strings.Contains(captured.Body, "timestamp < toDateTime(") {
+		t.Errorf("query should contain an upper window bound, got:\n%s", captured.Body)
+	}
+	if !strings.Contains(captured.Body, "FROM test_dataset") {
+		t.Errorf("query should contain dataset name, got:\n%s", captured.Body)
+	}
+	if !strings.Contains(captured.Body, "FORMAT JSON") {
+		t.Errorf("query should contain FORMAT JSON, got:\n%s", captured.Body)
+	}
+	if !strings.Contains(captured.Body, "AVG(double2) AS avg_latency_ms") {
+		t.Errorf("query should contain latency aggregation, got:\n%s", captured.Body)
+	}
+}
+
+func TestUpdateMetrics_QueryInterpolation_NoEscaping(t *testing.T) {
+	// Account name is allowlist-validated at config load (see pkg/cfg). The
+	// runtime query interpolates it directly without escaping; if a name
+	// containing a single quote ever reached this code path it would terminate
+	// the string literal and break the query, which is the failure we want.
+	emptyResp := `{"meta":[],"data":[],"rows":0}`
+	client, captured := captureRequestClient(emptyResp)
+
+	m := newTestManager()
+	m.AccountCfg.Name = "acme-prod"
+	m.httpClient = client
+
+	_ = m.UpdateMetrics()
+
+	if !strings.Contains(captured.Body, "index1 = 'acme-prod'") {
+		t.Errorf("expected literal account name in WHERE clause, got:\n%s", captured.Body)
+	}
+	if strings.Contains(captured.Body, `\'`) {
+		t.Errorf("query should not contain backslash escapes (validation guarantees safe names), got:\n%s", captured.Body)
+	}
+}
+
+func TestUpdateMetrics_MissingLatency_NoError(t *testing.T) {
+	resetMetrics()
+	m := newTestManager()
+	// AE row missing the avg_latency_ms field — defensive against partial responses.
+	m.httpClient = makeAEResponseClient([]map[string]any{
+		{"metric_name": "processed", "ip_type": "ipv4", "origin": "", "remediation_type": "", "val": 5.0},
+	})
+
+	if err := m.UpdateMetrics(); err != nil {
+		t.Fatalf("UpdateMetrics failed: %v", err)
+	}
+
+	processed := gaugeValue(metrics.TotalProcessedRequests.With(prometheus.Labels{
+		"ip_type": "ipv4", "account": "test-account",
+	}))
+	if processed != 5.0 {
+		t.Errorf("processed = %f, want 5", processed)
+	}
+}
+
+// ============================================================
+// Group 3: cleanupLegacyD1Databases
+// ============================================================
+
+func TestCleanupLegacyD1_FindsAndDeletes(t *testing.T) {
+	mock := &mockCFAPI{
+		listD1DatabasesFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error) {
+			return []cf.D1Database{
+				{UUID: "db-legacy", Name: "CROWDSECCFBOUNCERDB"},
+				{UUID: "db-other", Name: "unrelated-database"},
+			}, nil, nil
+		},
+	}
+
+	m := newTestManager()
+	m.api = mock
+	m.cleanupLegacyD1Databases()
+
+	if len(mock.deleteD1Calls) != 1 {
+		t.Fatalf("expected 1 delete call, got %d", len(mock.deleteD1Calls))
+	}
+	if mock.deleteD1Calls[0] != "db-legacy" {
+		t.Errorf("deleted %q, want db-legacy", mock.deleteD1Calls[0])
+	}
+}
+
+func TestCleanupLegacyD1_NoneFound(t *testing.T) {
+	mock := &mockCFAPI{
+		listD1DatabasesFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error) {
+			return []cf.D1Database{
+				{UUID: "db-other", Name: "unrelated-database"},
+			}, nil, nil
+		},
+	}
+
+	m := newTestManager()
+	m.api = mock
+	m.cleanupLegacyD1Databases()
+
+	if len(mock.deleteD1Calls) != 0 {
+		t.Errorf("expected 0 delete calls, got %d", len(mock.deleteD1Calls))
+	}
+}
+
+func TestCleanupLegacyD1_ListError(t *testing.T) {
+	mock := &mockCFAPI{
+		listD1DatabasesFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error) {
+			return nil, nil, errors.New("permission denied")
+		},
+	}
+
+	m := newTestManager()
+	m.api = mock
+	// Should not panic or propagate error
+	m.cleanupLegacyD1Databases()
+
+	if len(mock.deleteD1Calls) != 0 {
+		t.Error("should not attempt deletes after list error")
+	}
+}
+
+func TestCleanupLegacyD1_DeleteError(t *testing.T) {
+	mock := &mockCFAPI{
+		listD1DatabasesFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListD1DatabasesParams) ([]cf.D1Database, *cf.ResultInfo, error) {
+			return []cf.D1Database{
+				{UUID: "db-legacy", Name: "CROWDSECCFBOUNCERDB"},
+			}, nil, nil
+		},
+		deleteD1DatabaseFn: func(_ context.Context, _ *cf.ResourceContainer, _ string) error {
+			return errors.New("delete failed")
+		},
+	}
+
+	m := newTestManager()
+	m.api = mock
+	// Should warn but not panic
+	m.cleanupLegacyD1Databases()
+
+	if len(mock.deleteD1Calls) != 1 {
+		t.Error("should have attempted delete despite failure")
+	}
+}
+
+// ============================================================
+// Group 4: cleanupKVNamespaces — multi-instance teardown safety
+// ============================================================
+
+// When two bouncer instances share a Cloudflare account with the same
+// kv_namespace_name, the worker-binding lookup is the authoritative way to
+// tell which namespace belongs to THIS instance — a naive title-match
+// would delete both, wiping the other instance's live decisions.
+func TestCleanupKVNamespaces_AttributedByBinding_DeletesOnlyBoundID(t *testing.T) {
+	mock := &mockCFAPI{
+		listWorkersKVNamespacesFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListWorkersKVNamespacesParams) ([]cf.WorkersKVNamespace, *cf.ResultInfo, error) {
+			return []cf.WorkersKVNamespace{
+				{ID: "ours-id", Title: "CROWDSECCFBOUNCERNS"},
+				{ID: "other-instance-id", Title: "CROWDSECCFBOUNCERNS"},
+				{ID: "unrelated-id", Title: "some-other-namespace"},
+			}, nil, nil
+		},
+	}
+
+	m := newTestManager()
+	m.api = mock
+	m.Worker.KVNameSpaceName = "CROWDSECCFBOUNCERNS"
+
+	boundIDs := map[string]struct{}{"ours-id": {}}
+	if err := m.cleanupKVNamespaces(boundIDs); err != nil {
+		t.Fatalf("cleanupKVNamespaces returned error: %v", err)
+	}
+
+	if len(mock.deleteKVCalls) != 1 {
+		t.Fatalf("expected exactly 1 KV delete, got %d: %v", len(mock.deleteKVCalls), mock.deleteKVCalls)
+	}
+	if mock.deleteKVCalls[0] != "ours-id" {
+		t.Errorf("deleted %q, want ours-id (would have wiped sibling instance)", mock.deleteKVCalls[0])
+	}
+}
+
+func TestCleanupKVNamespaces_NoBindings_FallsBackToTitleMatch(t *testing.T) {
+	mock := &mockCFAPI{
+		listWorkersKVNamespacesFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListWorkersKVNamespacesParams) ([]cf.WorkersKVNamespace, *cf.ResultInfo, error) {
+			return []cf.WorkersKVNamespace{
+				{ID: "id-a", Title: "CROWDSECCFBOUNCERNS"},
+				{ID: "id-b", Title: "CROWDSECCFBOUNCERNS"},
+				{ID: "id-c", Title: "unrelated"},
+			}, nil, nil
+		},
+	}
+
+	m := newTestManager()
+	m.api = mock
+	m.Worker.KVNameSpaceName = "CROWDSECCFBOUNCERNS"
+
+	if err := m.cleanupKVNamespaces(map[string]struct{}{}); err != nil {
+		t.Fatalf("cleanupKVNamespaces returned error: %v", err)
+	}
+
+	// Fallback path: both title-matches get deleted (the WARN log makes the
+	// operator aware of the collision risk; positive attribution is preferred).
+	if len(mock.deleteKVCalls) != 2 {
+		t.Fatalf("expected 2 deletes in fallback, got %d: %v", len(mock.deleteKVCalls), mock.deleteKVCalls)
+	}
+}
+
+func TestCleanupKVNamespaces_NoMatches_NoOp(t *testing.T) {
+	mock := &mockCFAPI{
+		listWorkersKVNamespacesFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListWorkersKVNamespacesParams) ([]cf.WorkersKVNamespace, *cf.ResultInfo, error) {
+			return []cf.WorkersKVNamespace{
+				{ID: "id-a", Title: "unrelated"},
+			}, nil, nil
+		},
+	}
+
+	m := newTestManager()
+	m.api = mock
+	m.Worker.KVNameSpaceName = "CROWDSECCFBOUNCERNS"
+
+	if err := m.cleanupKVNamespaces(map[string]struct{}{}); err != nil {
+		t.Fatalf("cleanupKVNamespaces returned error: %v", err)
+	}
+	if len(mock.deleteKVCalls) != 0 {
+		t.Errorf("expected no deletes, got %d", len(mock.deleteKVCalls))
+	}
+}
+
+func TestFindBoundKVNamespaceIDs_QueriesBothWorkerScripts(t *testing.T) {
+	queried := []string{}
+	mock := &mockCFAPI{
+		listWorkerBindingsFn: func(_ context.Context, _ *cf.ResourceContainer, params cf.ListWorkerBindingsParams) (cf.WorkerBindingListResponse, error) {
+			queried = append(queried, params.ScriptName)
+			switch params.ScriptName {
+			case "main-worker":
+				return cf.WorkerBindingListResponse{
+					BindingList: []cf.WorkerBindingListItem{
+						{Name: cfg.KVWorkerBindingName, Binding: cf.WorkerKvNamespaceBinding{NamespaceID: "ns-main"}},
+						{Name: "SOME_OTHER", Binding: cf.WorkerPlainTextBinding{Text: "x"}},
+					},
+				}, nil
+			case "sync-worker":
+				return cf.WorkerBindingListResponse{
+					BindingList: []cf.WorkerBindingListItem{
+						{Name: cfg.KVWorkerBindingName, Binding: cf.WorkerKvNamespaceBinding{NamespaceID: "ns-sync"}},
+					},
+				}, nil
+			}
+			return cf.WorkerBindingListResponse{}, nil
+		},
+	}
+
+	m := newTestManager()
+	m.api = mock
+	m.Worker.ScriptName = "main-worker"
+	m.Worker.DecisionsSyncScriptName = "sync-worker"
+
+	ids := m.findBoundKVNamespaceIDs()
+
+	if len(queried) != 2 {
+		t.Errorf("expected to query 2 worker scripts, queried %d: %v", len(queried), queried)
+	}
+	if _, ok := ids["ns-main"]; !ok {
+		t.Errorf("missing main worker's KV id; got %v", ids)
+	}
+	if _, ok := ids["ns-sync"]; !ok {
+		t.Errorf("missing sync worker's KV id; got %v", ids)
+	}
+}
+
+func TestFindBoundKVNamespaceIDs_HandlesNotFoundError(t *testing.T) {
+	mock := &mockCFAPI{
+		listWorkerBindingsFn: func(_ context.Context, _ *cf.ResourceContainer, _ cf.ListWorkerBindingsParams) (cf.WorkerBindingListResponse, error) {
+			return cf.WorkerBindingListResponse{}, &cf.NotFoundError{}
+		},
+	}
+
+	m := newTestManager()
+	m.api = mock
+	m.Worker.ScriptName = "missing-worker"
+	m.Worker.DecisionsSyncScriptName = "missing-sync"
+
+	ids := m.findBoundKVNamespaceIDs()
+
+	if len(ids) != 0 {
+		t.Errorf("expected empty result on 404, got %v", ids)
+	}
+}
+
+// ============================================================
+// Group 5: Manager Initialization
+// ============================================================
+
+func TestManagerInit_LastMetricsPollSet(t *testing.T) {
+	m := newTestManager()
+	if m.lastMetricsPoll.IsZero() {
+		t.Error("lastMetricsPoll should not be zero")
+	}
+	elapsed := time.Since(m.lastMetricsPoll)
+	if elapsed > 3*time.Minute || elapsed < 1*time.Minute {
+		t.Errorf("lastMetricsPoll should be ~2min ago, got %v ago", elapsed)
+	}
+}
+
+func TestManagerInit_CumulativeMetricsMap(t *testing.T) {
+	m := newTestManager()
+	if m.cumulativeMetrics == nil {
+		t.Error("cumulativeMetrics should not be nil")
+	}
+	if len(m.cumulativeMetrics) != 0 {
+		t.Errorf("cumulativeMetrics should be empty, got %v", m.cumulativeMetrics)
+	}
+}
+
+func TestManagerInit_HttpClientSet(t *testing.T) {
+	m := newTestManager()
+	if m.httpClient == nil {
+		t.Error("httpClient should not be nil")
+	}
+}
+
+// obsFromBody extracts the observability section from a JSON request body.
+func obsFromBody(t *testing.T, rawBody string) map[string]any {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal([]byte(rawBody), &body); err != nil {
+		t.Fatalf("body is not valid JSON: %v", err)
+	}
+	obs, ok := body["observability"].(map[string]any)
+	if !ok {
+		t.Fatal("body missing observability key")
+	}
+	return obs
+}
+
+func tracesFromObs(t *testing.T, obs map[string]any) map[string]any {
+	t.Helper()
+	traces, ok := obs["traces"].(map[string]any)
+	if !ok {
+		t.Fatal("body missing observability.traces key")
+	}
+	return traces
+}
+
+// --- Group 5: enableWorkerObservability ---
+
+func TestEnableObservability_NilConfig_Skipped(t *testing.T) {
+	m := newTestManager()
+	// Transport that fails if any request is made
+	m.httpClient = &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			t.Fatal("no HTTP request should be made when observability is nil")
+			return nil, errors.New("unreachable")
+		}),
+	}
+	m.Worker.Observability = nil
+
+	if err := m.enableWorkerObservability("test-worker"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnableObservability_SendsCorrectRequest(t *testing.T) {
+	m := newTestManager()
+	client, captured := captureRequestClient(`{"success":true}`)
+	m.httpClient = client
+
+	enabled := true
+	rate := 1.0
+	m.Worker.Observability = &cfg.WorkerObservabilityConfig{
+		Enabled:          &enabled,
+		HeadSamplingRate: &rate,
+	}
+
+	if err := m.enableWorkerObservability("my-worker"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if captured.Request.Method != http.MethodPatch {
+		t.Errorf("method = %s, want PATCH", captured.Request.Method)
+	}
+	wantURL := "https://api.cloudflare.com/client/v4/accounts/test-account-id/workers/scripts/my-worker/script-settings"
+	if captured.Request.URL.String() != wantURL {
+		t.Errorf("URL = %s, want %s", captured.Request.URL.String(), wantURL)
+	}
+	if captured.Request.Header.Get("Authorization") != "Bearer test-token" {
+		t.Errorf("Authorization = %q, want %q", captured.Request.Header.Get("Authorization"), "Bearer test-token")
+	}
+	if captured.Request.Header.Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", captured.Request.Header.Get("Content-Type"))
+	}
+
+	obs := obsFromBody(t, captured.Body)
+	if enabled, ok := obs["enabled"].(bool); !ok || !enabled {
+		t.Errorf("enabled = %v, want true", obs["enabled"])
+	}
+	if obs["head_sampling_rate"] != 1.0 {
+		t.Errorf("head_sampling_rate = %v, want 1", obs["head_sampling_rate"])
+	}
+
+	traces := tracesFromObs(t, obs)
+	if enabled, ok := traces["enabled"].(bool); !ok || !enabled {
+		t.Errorf("traces.enabled = %v, want true", traces["enabled"])
+	}
+	if traces["head_sampling_rate"] != 1.0 {
+		t.Errorf("traces.head_sampling_rate = %v, want 1", traces["head_sampling_rate"])
+	}
+}
+
+func TestEnableObservability_CustomSamplingRate(t *testing.T) {
+	m := newTestManager()
+	client, captured := captureRequestClient(`{"success":true}`)
+	m.httpClient = client
+
+	enabled := true
+	rate := 0.05
+	m.Worker.Observability = &cfg.WorkerObservabilityConfig{
+		Enabled:          &enabled,
+		HeadSamplingRate: &rate,
+	}
+
+	if err := m.enableWorkerObservability("my-worker"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obs := obsFromBody(t, captured.Body)
+	if obs["head_sampling_rate"] != 0.05 {
+		t.Errorf("head_sampling_rate = %v, want 0.05", obs["head_sampling_rate"])
+	}
+}
+
+func TestEnableObservability_HTTPError(t *testing.T) {
+	m := newTestManager()
+	m.httpClient = makeAEErrorClient(500, "internal server error")
+
+	enabled := true
+	m.Worker.Observability = &cfg.WorkerObservabilityConfig{Enabled: &enabled}
+
+	err := m.enableWorkerObservability("my-worker")
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error should contain status code: %v", err)
+	}
+}
+
+func TestEnableObservability_DefaultValues(t *testing.T) {
+	m := newTestManager()
+	client, captured := captureRequestClient(`{"success":true}`)
+	m.httpClient = client
+
+	// Non-nil config but both fields nil — should default to enabled=true, rate=1.0
+	m.Worker.Observability = &cfg.WorkerObservabilityConfig{}
+
+	if err := m.enableWorkerObservability("my-worker"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obs := obsFromBody(t, captured.Body)
+	if enabled, ok := obs["enabled"].(bool); !ok || !enabled {
+		t.Errorf("enabled = %v, want true (default)", obs["enabled"])
+	}
+	if obs["head_sampling_rate"] != 1.0 {
+		t.Errorf("head_sampling_rate = %v, want 1.0 (default)", obs["head_sampling_rate"])
+	}
+
+	// Traces should inherit top-level defaults
+	traces := tracesFromObs(t, obs)
+	if enabled, ok := traces["enabled"].(bool); !ok || !enabled {
+		t.Errorf("traces.enabled = %v, want true (default)", traces["enabled"])
+	}
+	if traces["head_sampling_rate"] != 1.0 {
+		t.Errorf("traces.head_sampling_rate = %v, want 1.0 (default)", traces["head_sampling_rate"])
+	}
+}
+
+func TestEnableObservability_NetworkError(t *testing.T) {
+	m := newTestManager()
+	m.httpClient = &http.Client{
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			return nil, errors.New("connection refused")
+		}),
+	}
+	enabled := true
+	m.Worker.Observability = &cfg.WorkerObservabilityConfig{Enabled: &enabled}
+
+	err := m.enableWorkerObservability("my-worker")
+	if err == nil {
+		t.Fatal("expected error for network failure")
+	}
+	if !strings.Contains(err.Error(), "observability settings request failed") {
+		t.Errorf("error should mention request failure: %v", err)
+	}
+}
+
+func TestEnableObservability_CustomTracesConfig(t *testing.T) {
+	m := newTestManager()
+	client, captured := captureRequestClient(`{"success":true}`)
+	m.httpClient = client
+
+	enabled := true
+	logRate := 1.0
+	traceRate := 0.1
+	m.Worker.Observability = &cfg.WorkerObservabilityConfig{
+		Enabled:          &enabled,
+		HeadSamplingRate: &logRate,
+		Traces: &cfg.WorkerTracesConfig{
+			Enabled:          &enabled,
+			HeadSamplingRate: &traceRate,
+		},
+	}
+
+	if err := m.enableWorkerObservability("my-worker"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obs := obsFromBody(t, captured.Body)
+	if obs["head_sampling_rate"] != 1.0 {
+		t.Errorf("log sampling rate = %v, want 1.0", obs["head_sampling_rate"])
+	}
+	traces := tracesFromObs(t, obs)
+	if traces["head_sampling_rate"] != 0.1 {
+		t.Errorf("trace sampling rate = %v, want 0.1", traces["head_sampling_rate"])
+	}
+}
+
+func TestEnableObservability_ExplicitlyDisabled(t *testing.T) {
+	m := newTestManager()
+	client, captured := captureRequestClient(`{"success":true}`)
+	m.httpClient = client
+
+	enabled := false
+	m.Worker.Observability = &cfg.WorkerObservabilityConfig{Enabled: &enabled}
+
+	if err := m.enableWorkerObservability("my-worker"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obs := obsFromBody(t, captured.Body)
+	if enabled, ok := obs["enabled"].(bool); !ok || enabled {
+		t.Errorf("enabled = %v, want false", obs["enabled"])
+	}
+}

--- a/pkg/cloudflare/decisions-sync-worker/dist/main.js
+++ b/pkg/cloudflare/decisions-sync-worker/dist/main.js
@@ -5681,6 +5681,10 @@ function error(message, context = {}) {
 
 const USER_AGENT = 'cloudflare-worker-bouncer/v1.0.0';
 const WARMED_UP_KEY = 'WARMED_UP';
+const SYNC_LOCK_KEY = 'SYNC_IN_PROGRESS';
+// TTL backstop in case a sync crashes before releaseSyncLock runs; without
+// this, a stuck lock would block every subsequent cron run.
+const SYNC_LOCK_TTL_SECONDS = 300;
 const SUPPORTED_SCOPES = ['ip', 'range', 'as', 'country'];
 
 /**
@@ -5694,12 +5698,46 @@ async function isFirstFetch(kvNamespace) {
 }
 
 /**
- * Mark the cache as warmed up (first fetch completed)
+ * Mark the cache as warmed up. MUST only be called after a sync has fully
+ * written all decisions to KV — calling it before commits a half-empty KV
+ * to "warmed" state, causing the next run to do an incremental fetch that
+ * never backfills the missed decisions (silent enforcement gap).
  * @param {KVNamespace} kvNamespace - Cloudflare KV namespace
  */
 async function markAsWarmed(kvNamespace) {
 	await kvNamespace.put(WARMED_UP_KEY, 'true');
 	logger.debug('Cache marked as warmed');
+}
+
+/**
+ * Try to acquire the sync lock. Returns true if acquired, false if another
+ * sync is already running. Caller MUST call releaseSyncLock in a finally
+ * block. The TTL is a backstop only — do not rely on it for normal release.
+ *
+ * NOTE: Workers KV has no atomic put-if-absent, so this is a best-effort
+ * advisory lock. A small race window exists between get() and put() where
+ * two near-simultaneous invocations can both observe `existing === null`
+ * and both proceed. With a 5-minute cron interval it's unlikely; LAPI's
+ * own rate limiting is the actual safety net against a sync storm.
+ *
+ * @param {KVNamespace} kvNamespace - Cloudflare KV namespace
+ * @returns {Promise<boolean>} True if the lock was acquired
+ */
+async function tryAcquireSyncLock(kvNamespace) {
+	const existing = await kvNamespace.get(SYNC_LOCK_KEY);
+	if (existing) {
+		return false;
+	}
+	await kvNamespace.put(SYNC_LOCK_KEY, 'true', { expirationTtl: SYNC_LOCK_TTL_SECONDS });
+	return true;
+}
+
+/**
+ * Release the sync lock acquired via tryAcquireSyncLock.
+ * @param {KVNamespace} kvNamespace - Cloudflare KV namespace
+ */
+async function releaseSyncLock(kvNamespace) {
+	await kvNamespace.delete(SYNC_LOCK_KEY);
 }
 
 /**
@@ -6407,146 +6445,168 @@ async function resetAllDecisions(accountId, namespaceId, apiToken, kvNamespace) 
 
 			const lapiUrl = env.LAPI_URL.replace(/\/$/, ''); // Remove trailing slash if present
 
-			// Check if reset is requested
-			const resetRequested = await shouldReset(env.CROWDSECCFBOUNCERNS);
-			if (resetRequested) {
-				logger.info('RESET requested: clearing all decision keys from KV...');
-				await resetAllDecisions(
-					env.CF_ACCOUNT_ID,
-					env.CF_KV_NAMESPACE_ID,
-					env.CF_API_TOKEN,
-					env.CROWDSECCFBOUNCERNS
-				);
-				logger.info('KV reset completed, proceeding with fresh decision sync');
+			// Acquire the sync lock so an overlapping cron tick (or a manual run
+			// while a previous one is still in flight) doesn't fan out into a
+			// full-sync storm against LAPI. Released in finally below; TTL is
+			// only a backstop for a hard crash.
+			const lockAcquired = await tryAcquireSyncLock(env.CROWDSECCFBOUNCERNS);
+			if (!lockAcquired) {
+				logger.info('Sync already in progress, skipping this run');
+				return;
 			}
 
-			// Determine if this is the first fetch
-			const isFirst = await isFirstFetch(env.CROWDSECCFBOUNCERNS);
-			logger.info('Fetch type determined', { isFirstFetch: isFirst });
+			try {
+				// Check if reset is requested
+				const resetRequested = await shouldReset(env.CROWDSECCFBOUNCERNS);
+				if (resetRequested) {
+					logger.info('RESET requested: clearing all decision keys from KV...');
+					await resetAllDecisions(
+						env.CF_ACCOUNT_ID,
+						env.CF_KV_NAMESPACE_ID,
+						env.CF_API_TOKEN,
+						env.CROWDSECCFBOUNCERNS
+					);
+					logger.info('KV reset completed, proceeding with fresh decision sync');
+				}
 
-			// Parse optional filter configuration
-			const scenariosContaining = env.INCLUDE_SCENARIOS ? env.INCLUDE_SCENARIOS.split(',').map((s) => s.trim()) : [];
-			const scenariosNotContaining = env.EXCLUDE_SCENARIOS ? env.EXCLUDE_SCENARIOS.split(',').map((s) => s.trim()) : [];
-			const origins = env.ONLY_INCLUDE_ORIGINS ? env.ONLY_INCLUDE_ORIGINS.split(',').map((s) => s.trim()) : [];
+				// Determine if this is the first fetch
+				const isFirst = await isFirstFetch(env.CROWDSECCFBOUNCERNS);
+				logger.info('Fetch type determined', { isFirstFetch: isFirst });
 
-			// Fetch decisions from LAPI
-			const decisions = await fetchDecisionsStream(lapiUrl, env.LAPI_KEY, {
-				startup: isFirst,
-				scenariosContaining,
-				scenariosNotContaining,
-				origins,
-			});
+				// Parse optional filter configuration
+				const scenariosContaining = env.INCLUDE_SCENARIOS ? env.INCLUDE_SCENARIOS.split(',').map((s) => s.trim()) : [];
+				const scenariosNotContaining = env.EXCLUDE_SCENARIOS ? env.EXCLUDE_SCENARIOS.split(',').map((s) => s.trim()) : [];
+				const origins = env.ONLY_INCLUDE_ORIGINS ? env.ONLY_INCLUDE_ORIGINS.split(',').map((s) => s.trim()) : [];
 
-			// Log summary
-			const duration = ((Date.now() - startTime) / 1000).toFixed(2);
-			logger.info('Decision stream completed successfully', {
-				duration: `${duration}s`,
-				newDecisions: decisions.new.length,
-				deletedDecisions: decisions.deleted.length,
-			});
-
-			// Handle HTTP 204 (LAPI has no decisions - delete all from KV)
-			if (decisions.deleteAll) {
-				logger.info('LAPI has no decisions (204): clearing all decision keys from KV...');
-				await resetAllDecisions(
-					env.CF_ACCOUNT_ID,
-					env.CF_KV_NAMESPACE_ID,
-					env.CF_API_TOKEN,
-					env.CROWDSECCFBOUNCERNS
-				);
-                // No need to handle WARMED_UP flag as there is no decisions at all
-				const finalDuration = ((Date.now() - startTime) / 1000).toFixed(2);
-				logger.info('KV cleared successfully (LAPI has no decisions)', {
-					totalDuration: `${finalDuration}s`,
+				// Fetch decisions from LAPI
+				const decisions = await fetchDecisionsStream(lapiUrl, env.LAPI_KEY, {
+					startup: isFirst,
+					scenariosContaining,
+					scenariosNotContaining,
+					origins,
 				});
-				return; // Exit early - no further sync needed
+
+				// Log summary
+				const duration = ((Date.now() - startTime) / 1000).toFixed(2);
+				logger.info('Decision stream completed successfully', {
+					duration: `${duration}s`,
+					newDecisions: decisions.new.length,
+					deletedDecisions: decisions.deleted.length,
+				});
+
+				// Handle HTTP 204 (LAPI has no decisions - delete all from KV)
+				if (decisions.deleteAll) {
+					logger.info('LAPI has no decisions (204): clearing all decision keys from KV...');
+					await resetAllDecisions(
+						env.CF_ACCOUNT_ID,
+						env.CF_KV_NAMESPACE_ID,
+						env.CF_API_TOKEN,
+						env.CROWDSECCFBOUNCERNS
+					);
+					// Safe to mark warmed here: KV is now in its intended empty state,
+					// so a crash at this point doesn't leave decisions unwritten.
+					if (isFirst) {
+						await markAsWarmed(env.CROWDSECCFBOUNCERNS);
+						logger.info('Cache marked as warmed (LAPI has no decisions)');
+					}
+					const finalDuration = ((Date.now() - startTime) / 1000).toFixed(2);
+					logger.info('KV cleared successfully (LAPI has no decisions)', {
+						totalDuration: `${finalDuration}s`,
+					});
+					return; // Exit early - no further sync needed
+				}
+
+				// ====================
+				// SYNC TO KV STORE
+				// ====================
+
+				logger.info('Starting KV sync...');
+
+				// Step 1: Get existing IP_RANGES from KV
+				const existingRanges = await getIpRanges(env.CROWDSECCFBOUNCERNS);
+
+				// Step 2: Check existing string decisions in KV (only on incremental updates, not first run)
+				let existingStringDecisions = new Map();
+
+				if (!isFirst) {
+					// On incremental updates, check existing values to avoid redundant writes
+					logger.debug('Incremental update: checking existing decisions in KV');
+					const allStringKeys = [
+						...decisions.new
+							.filter((d) => ['ip', 'as', 'country'].includes(d.scope))
+							.map((d) => (d.scope === 'country' ? d.value.toLowerCase() : d.value)),
+						...decisions.deleted
+							.filter((d) => ['ip', 'as', 'country'].includes(d.scope))
+							.map((d) => (d.scope === 'country' ? d.value.toLowerCase() : d.value)),
+					];
+
+					// Remove duplicates
+					const uniqueStringKeys = [...new Set(allStringKeys)];
+
+					// Fetch existing string decisions from KV using bulk API
+					existingStringDecisions = await batchGetStringBasedDecisions(
+						env.CF_ACCOUNT_ID,
+						env.CF_KV_NAMESPACE_ID,
+						env.CF_API_TOKEN,
+						uniqueStringKeys
+					);
+				} else {
+					logger.debug('First run: skipping existence check (KV is empty)');
+				}
+
+				// Step 3: Process new decisions
+				const newProcessed = processNewDecisions(decisions.new, existingStringDecisions, existingRanges);
+				// Step 4: Process deleted decisions
+				const deletedProcessed = processDeletedDecisions(decisions.deleted, existingStringDecisions, existingRanges);
+				// Step 5: Merge ranges (deletions already applied in step 4, now adding new ranges)
+				const finalRanges = mergeRanges(deletedProcessed.updatedRanges, newProcessed.jsonEntries);
+				// Step 6: Write new/updated string decisions (IP, AS, Country) to KV using bulk API
+				if (newProcessed.stringEntries.length > 0) {
+					logger.info('Writing string-based decisions to KV...', { count: newProcessed.stringEntries.length });
+					await batchWriteStringBasedDecisions(
+						env.CF_ACCOUNT_ID,
+						env.CF_KV_NAMESPACE_ID,
+						env.CF_API_TOKEN,
+						newProcessed.stringEntries
+					);
+				}
+				// Step 7: Delete string decisions from KV using bulk API
+				if (deletedProcessed.stringKeysToDelete.length > 0) {
+					logger.info('Deleting string decisions from KV...', { count: deletedProcessed.stringKeysToDelete.length });
+					await batchDeleteStringBasedDecisions(
+						env.CF_ACCOUNT_ID,
+						env.CF_KV_NAMESPACE_ID,
+						env.CF_API_TOKEN,
+						deletedProcessed.stringKeysToDelete
+					);
+				}
+				// Step 8: Update IP_RANGES if changed
+				if (hasRangesChanged(existingRanges, finalRanges)) {
+					logger.info('IP_RANGES changed, updating KV...');
+					await writeIpRanges(env.CROWDSECCFBOUNCERNS, finalRanges);
+				}
+
+				// Step 9: Mark cache as warmed ONLY after all KV writes have succeeded.
+				// If this runs before the writes, a mid-sync crash leaves WARMED_UP=true
+				// with an empty KV, and the next run does an incremental fetch that
+				// never backfills the missed decisions — a silent enforcement gap.
+				if (isFirst) {
+					await markAsWarmed(env.CROWDSECCFBOUNCERNS);
+					logger.info('Cache marked as warmed (first sync complete)');
+				}
+
+				// Final summary
+				const finalDuration = ((Date.now() - startTime) / 1000).toFixed(2);
+
+				logger.info('KV sync completed successfully', {
+					totalDuration: `${finalDuration}s`,
+					stringWritten: newProcessed.stringEntries.length,
+					stringDeleted: deletedProcessed.stringKeysToDelete.length,
+					rangesCount: Object.keys(finalRanges).length,
+				});
+			} finally {
+				await releaseSyncLock(env.CROWDSECCFBOUNCERNS);
 			}
-
-			// ====================
-			// SYNC TO KV STORE
-			// ====================
-
-			logger.info('Starting KV sync...');
-
-			// Step 1: Get existing IP_RANGES from KV
-			const existingRanges = await getIpRanges(env.CROWDSECCFBOUNCERNS);
-
-			// Step 2: Check existing string decisions in KV (only on incremental updates, not first run)
-			let existingStringDecisions = new Map();
-
-			if (!isFirst) {
-				// On incremental updates, check existing values to avoid redundant writes
-				logger.debug('Incremental update: checking existing decisions in KV');
-				const allStringKeys = [
-					...decisions.new
-						.filter((d) => ['ip', 'as', 'country'].includes(d.scope))
-						.map((d) => (d.scope === 'country' ? d.value.toLowerCase() : d.value)),
-					...decisions.deleted
-						.filter((d) => ['ip', 'as', 'country'].includes(d.scope))
-						.map((d) => (d.scope === 'country' ? d.value.toLowerCase() : d.value)),
-				];
-
-				// Remove duplicates
-				const uniqueStringKeys = [...new Set(allStringKeys)];
-
-				// Fetch existing string decisions from KV using bulk API
-				existingStringDecisions = await batchGetStringBasedDecisions(
-					env.CF_ACCOUNT_ID,
-					env.CF_KV_NAMESPACE_ID,
-					env.CF_API_TOKEN,
-					uniqueStringKeys
-				);
-			} else {
-				logger.debug('First run: skipping existence check (KV is empty)');
-			}
-
-			// Step 3: Process new decisions
-			const newProcessed = processNewDecisions(decisions.new, existingStringDecisions, existingRanges);
-			// Step 4: Process deleted decisions
-			const deletedProcessed = processDeletedDecisions(decisions.deleted, existingStringDecisions, existingRanges);
-			// Step 5: Merge ranges (deletions already applied in step 4, now adding new ranges)
-			const finalRanges = mergeRanges(deletedProcessed.updatedRanges, newProcessed.jsonEntries);
-			// Step 6: Write new/updated string decisions (IP, AS, Country) to KV using bulk API
-			if (newProcessed.stringEntries.length > 0) {
-				logger.info('Writing string-based decisions to KV...', { count: newProcessed.stringEntries.length });
-				await batchWriteStringBasedDecisions(
-					env.CF_ACCOUNT_ID,
-					env.CF_KV_NAMESPACE_ID,
-					env.CF_API_TOKEN,
-					newProcessed.stringEntries
-				);
-			}
-			// Step 7: Delete string decisions from KV using bulk API
-			if (deletedProcessed.stringKeysToDelete.length > 0) {
-				logger.info('Deleting string decisions from KV...', { count: deletedProcessed.stringKeysToDelete.length });
-				await batchDeleteStringBasedDecisions(
-					env.CF_ACCOUNT_ID,
-					env.CF_KV_NAMESPACE_ID,
-					env.CF_API_TOKEN,
-					deletedProcessed.stringKeysToDelete
-				);
-			}
-			// Step 8: Update IP_RANGES if changed
-			if (hasRangesChanged(existingRanges, finalRanges)) {
-				logger.info('IP_RANGES changed, updating KV...');
-				await writeIpRanges(env.CROWDSECCFBOUNCERNS, finalRanges);
-			}
-
-            // Step 9: Mark cache as warmed after first successful fetch
-            if (isFirst) {
-                await markAsWarmed(env.CROWDSECCFBOUNCERNS);
-                logger.info('Cache marked as warmed after first fetch');
-            }
-
-			// Final summary
-			const finalDuration = ((Date.now() - startTime) / 1000).toFixed(2);
-
-			logger.info('KV sync completed successfully', {
-				totalDuration: `${finalDuration}s`,
-				stringWritten: newProcessed.stringEntries.length,
-				stringDeleted: deletedProcessed.stringKeysToDelete.length,
-				rangesCount: Object.keys(finalRanges).length,
-			});
 		} catch (error) {
 			const duration = ((Date.now() - startTime) / 1000).toFixed(2);
 			logger.error('Decision sync failed', {

--- a/pkg/cloudflare/decisions-sync-worker/src/core/decision-fetcher.js
+++ b/pkg/cloudflare/decisions-sync-worker/src/core/decision-fetcher.js
@@ -8,6 +8,10 @@ import logger from '../utils/logger.js';
 
 const USER_AGENT = 'cloudflare-worker-bouncer/v1.0.0';
 const WARMED_UP_KEY = 'WARMED_UP';
+const SYNC_LOCK_KEY = 'SYNC_IN_PROGRESS';
+// TTL backstop in case a sync crashes before releaseSyncLock runs; without
+// this, a stuck lock would block every subsequent cron run.
+const SYNC_LOCK_TTL_SECONDS = 300;
 const SUPPORTED_SCOPES = ['ip', 'range', 'as', 'country'];
 
 /**
@@ -21,12 +25,46 @@ export async function isFirstFetch(kvNamespace) {
 }
 
 /**
- * Mark the cache as warmed up (first fetch completed)
+ * Mark the cache as warmed up. MUST only be called after a sync has fully
+ * written all decisions to KV — calling it before commits a half-empty KV
+ * to "warmed" state, causing the next run to do an incremental fetch that
+ * never backfills the missed decisions (silent enforcement gap).
  * @param {KVNamespace} kvNamespace - Cloudflare KV namespace
  */
 export async function markAsWarmed(kvNamespace) {
 	await kvNamespace.put(WARMED_UP_KEY, 'true');
 	logger.debug('Cache marked as warmed');
+}
+
+/**
+ * Try to acquire the sync lock. Returns true if acquired, false if another
+ * sync is already running. Caller MUST call releaseSyncLock in a finally
+ * block. The TTL is a backstop only — do not rely on it for normal release.
+ *
+ * NOTE: Workers KV has no atomic put-if-absent, so this is a best-effort
+ * advisory lock. A small race window exists between get() and put() where
+ * two near-simultaneous invocations can both observe `existing === null`
+ * and both proceed. With a 5-minute cron interval it's unlikely; LAPI's
+ * own rate limiting is the actual safety net against a sync storm.
+ *
+ * @param {KVNamespace} kvNamespace - Cloudflare KV namespace
+ * @returns {Promise<boolean>} True if the lock was acquired
+ */
+export async function tryAcquireSyncLock(kvNamespace) {
+	const existing = await kvNamespace.get(SYNC_LOCK_KEY);
+	if (existing) {
+		return false;
+	}
+	await kvNamespace.put(SYNC_LOCK_KEY, 'true', { expirationTtl: SYNC_LOCK_TTL_SECONDS });
+	return true;
+}
+
+/**
+ * Release the sync lock acquired via tryAcquireSyncLock.
+ * @param {KVNamespace} kvNamespace - Cloudflare KV namespace
+ */
+export async function releaseSyncLock(kvNamespace) {
+	await kvNamespace.delete(SYNC_LOCK_KEY);
 }
 
 /**

--- a/pkg/cloudflare/decisions-sync-worker/src/index.js
+++ b/pkg/cloudflare/decisions-sync-worker/src/index.js
@@ -4,7 +4,13 @@
  */
 
 import logger from './utils/logger.js';
-import { isFirstFetch, markAsWarmed, fetchDecisionsStream } from './core/decision-fetcher.js';
+import {
+	isFirstFetch,
+	markAsWarmed,
+	fetchDecisionsStream,
+	tryAcquireSyncLock,
+	releaseSyncLock,
+} from './core/decision-fetcher.js';
 import { processNewDecisions, processDeletedDecisions, mergeRanges, hasRangesChanged } from './core/decision-processor.js';
 import {
 	batchWriteStringBasedDecisions,
@@ -62,146 +68,168 @@ export default {
 
 			const lapiUrl = env.LAPI_URL.replace(/\/$/, ''); // Remove trailing slash if present
 
-			// Check if reset is requested
-			const resetRequested = await shouldReset(env.CROWDSECCFBOUNCERNS);
-			if (resetRequested) {
-				logger.info('RESET requested: clearing all decision keys from KV...');
-				await resetAllDecisions(
-					env.CF_ACCOUNT_ID,
-					env.CF_KV_NAMESPACE_ID,
-					env.CF_API_TOKEN,
-					env.CROWDSECCFBOUNCERNS
-				);
-				logger.info('KV reset completed, proceeding with fresh decision sync');
+			// Acquire the sync lock so an overlapping cron tick (or a manual run
+			// while a previous one is still in flight) doesn't fan out into a
+			// full-sync storm against LAPI. Released in finally below; TTL is
+			// only a backstop for a hard crash.
+			const lockAcquired = await tryAcquireSyncLock(env.CROWDSECCFBOUNCERNS);
+			if (!lockAcquired) {
+				logger.info('Sync already in progress, skipping this run');
+				return;
 			}
 
-			// Determine if this is the first fetch
-			const isFirst = await isFirstFetch(env.CROWDSECCFBOUNCERNS);
-			logger.info('Fetch type determined', { isFirstFetch: isFirst });
+			try {
+				// Check if reset is requested
+				const resetRequested = await shouldReset(env.CROWDSECCFBOUNCERNS);
+				if (resetRequested) {
+					logger.info('RESET requested: clearing all decision keys from KV...');
+					await resetAllDecisions(
+						env.CF_ACCOUNT_ID,
+						env.CF_KV_NAMESPACE_ID,
+						env.CF_API_TOKEN,
+						env.CROWDSECCFBOUNCERNS
+					);
+					logger.info('KV reset completed, proceeding with fresh decision sync');
+				}
 
-			// Parse optional filter configuration
-			const scenariosContaining = env.INCLUDE_SCENARIOS ? env.INCLUDE_SCENARIOS.split(',').map((s) => s.trim()) : [];
-			const scenariosNotContaining = env.EXCLUDE_SCENARIOS ? env.EXCLUDE_SCENARIOS.split(',').map((s) => s.trim()) : [];
-			const origins = env.ONLY_INCLUDE_ORIGINS ? env.ONLY_INCLUDE_ORIGINS.split(',').map((s) => s.trim()) : [];
+				// Determine if this is the first fetch
+				const isFirst = await isFirstFetch(env.CROWDSECCFBOUNCERNS);
+				logger.info('Fetch type determined', { isFirstFetch: isFirst });
 
-			// Fetch decisions from LAPI
-			const decisions = await fetchDecisionsStream(lapiUrl, env.LAPI_KEY, {
-				startup: isFirst,
-				scenariosContaining,
-				scenariosNotContaining,
-				origins,
-			});
+				// Parse optional filter configuration
+				const scenariosContaining = env.INCLUDE_SCENARIOS ? env.INCLUDE_SCENARIOS.split(',').map((s) => s.trim()) : [];
+				const scenariosNotContaining = env.EXCLUDE_SCENARIOS ? env.EXCLUDE_SCENARIOS.split(',').map((s) => s.trim()) : [];
+				const origins = env.ONLY_INCLUDE_ORIGINS ? env.ONLY_INCLUDE_ORIGINS.split(',').map((s) => s.trim()) : [];
 
-			// Log summary
-			const duration = ((Date.now() - startTime) / 1000).toFixed(2);
-			logger.info('Decision stream completed successfully', {
-				duration: `${duration}s`,
-				newDecisions: decisions.new.length,
-				deletedDecisions: decisions.deleted.length,
-			});
-
-			// Handle HTTP 204 (LAPI has no decisions - delete all from KV)
-			if (decisions.deleteAll) {
-				logger.info('LAPI has no decisions (204): clearing all decision keys from KV...');
-				await resetAllDecisions(
-					env.CF_ACCOUNT_ID,
-					env.CF_KV_NAMESPACE_ID,
-					env.CF_API_TOKEN,
-					env.CROWDSECCFBOUNCERNS
-				);
-                // No need to handle WARMED_UP flag as there is no decisions at all
-				const finalDuration = ((Date.now() - startTime) / 1000).toFixed(2);
-				logger.info('KV cleared successfully (LAPI has no decisions)', {
-					totalDuration: `${finalDuration}s`,
+				// Fetch decisions from LAPI
+				const decisions = await fetchDecisionsStream(lapiUrl, env.LAPI_KEY, {
+					startup: isFirst,
+					scenariosContaining,
+					scenariosNotContaining,
+					origins,
 				});
-				return; // Exit early - no further sync needed
+
+				// Log summary
+				const duration = ((Date.now() - startTime) / 1000).toFixed(2);
+				logger.info('Decision stream completed successfully', {
+					duration: `${duration}s`,
+					newDecisions: decisions.new.length,
+					deletedDecisions: decisions.deleted.length,
+				});
+
+				// Handle HTTP 204 (LAPI has no decisions - delete all from KV)
+				if (decisions.deleteAll) {
+					logger.info('LAPI has no decisions (204): clearing all decision keys from KV...');
+					await resetAllDecisions(
+						env.CF_ACCOUNT_ID,
+						env.CF_KV_NAMESPACE_ID,
+						env.CF_API_TOKEN,
+						env.CROWDSECCFBOUNCERNS
+					);
+					// Safe to mark warmed here: KV is now in its intended empty state,
+					// so a crash at this point doesn't leave decisions unwritten.
+					if (isFirst) {
+						await markAsWarmed(env.CROWDSECCFBOUNCERNS);
+						logger.info('Cache marked as warmed (LAPI has no decisions)');
+					}
+					const finalDuration = ((Date.now() - startTime) / 1000).toFixed(2);
+					logger.info('KV cleared successfully (LAPI has no decisions)', {
+						totalDuration: `${finalDuration}s`,
+					});
+					return; // Exit early - no further sync needed
+				}
+
+				// ====================
+				// SYNC TO KV STORE
+				// ====================
+
+				logger.info('Starting KV sync...');
+
+				// Step 1: Get existing IP_RANGES from KV
+				const existingRanges = await getIpRanges(env.CROWDSECCFBOUNCERNS);
+
+				// Step 2: Check existing string decisions in KV (only on incremental updates, not first run)
+				let existingStringDecisions = new Map();
+
+				if (!isFirst) {
+					// On incremental updates, check existing values to avoid redundant writes
+					logger.debug('Incremental update: checking existing decisions in KV');
+					const allStringKeys = [
+						...decisions.new
+							.filter((d) => ['ip', 'as', 'country'].includes(d.scope))
+							.map((d) => (d.scope === 'country' ? d.value.toLowerCase() : d.value)),
+						...decisions.deleted
+							.filter((d) => ['ip', 'as', 'country'].includes(d.scope))
+							.map((d) => (d.scope === 'country' ? d.value.toLowerCase() : d.value)),
+					];
+
+					// Remove duplicates
+					const uniqueStringKeys = [...new Set(allStringKeys)];
+
+					// Fetch existing string decisions from KV using bulk API
+					existingStringDecisions = await batchGetStringBasedDecisions(
+						env.CF_ACCOUNT_ID,
+						env.CF_KV_NAMESPACE_ID,
+						env.CF_API_TOKEN,
+						uniqueStringKeys
+					);
+				} else {
+					logger.debug('First run: skipping existence check (KV is empty)');
+				}
+
+				// Step 3: Process new decisions
+				const newProcessed = processNewDecisions(decisions.new, existingStringDecisions, existingRanges);
+				// Step 4: Process deleted decisions
+				const deletedProcessed = processDeletedDecisions(decisions.deleted, existingStringDecisions, existingRanges);
+				// Step 5: Merge ranges (deletions already applied in step 4, now adding new ranges)
+				const finalRanges = mergeRanges(deletedProcessed.updatedRanges, newProcessed.jsonEntries);
+				// Step 6: Write new/updated string decisions (IP, AS, Country) to KV using bulk API
+				if (newProcessed.stringEntries.length > 0) {
+					logger.info('Writing string-based decisions to KV...', { count: newProcessed.stringEntries.length });
+					await batchWriteStringBasedDecisions(
+						env.CF_ACCOUNT_ID,
+						env.CF_KV_NAMESPACE_ID,
+						env.CF_API_TOKEN,
+						newProcessed.stringEntries
+					);
+				}
+				// Step 7: Delete string decisions from KV using bulk API
+				if (deletedProcessed.stringKeysToDelete.length > 0) {
+					logger.info('Deleting string decisions from KV...', { count: deletedProcessed.stringKeysToDelete.length });
+					await batchDeleteStringBasedDecisions(
+						env.CF_ACCOUNT_ID,
+						env.CF_KV_NAMESPACE_ID,
+						env.CF_API_TOKEN,
+						deletedProcessed.stringKeysToDelete
+					);
+				}
+				// Step 8: Update IP_RANGES if changed
+				if (hasRangesChanged(existingRanges, finalRanges)) {
+					logger.info('IP_RANGES changed, updating KV...');
+					await writeIpRanges(env.CROWDSECCFBOUNCERNS, finalRanges);
+				}
+
+				// Step 9: Mark cache as warmed ONLY after all KV writes have succeeded.
+				// If this runs before the writes, a mid-sync crash leaves WARMED_UP=true
+				// with an empty KV, and the next run does an incremental fetch that
+				// never backfills the missed decisions — a silent enforcement gap.
+				if (isFirst) {
+					await markAsWarmed(env.CROWDSECCFBOUNCERNS);
+					logger.info('Cache marked as warmed (first sync complete)');
+				}
+
+				// Final summary
+				const finalDuration = ((Date.now() - startTime) / 1000).toFixed(2);
+
+				logger.info('KV sync completed successfully', {
+					totalDuration: `${finalDuration}s`,
+					stringWritten: newProcessed.stringEntries.length,
+					stringDeleted: deletedProcessed.stringKeysToDelete.length,
+					rangesCount: Object.keys(finalRanges).length,
+				});
+			} finally {
+				await releaseSyncLock(env.CROWDSECCFBOUNCERNS);
 			}
-
-			// ====================
-			// SYNC TO KV STORE
-			// ====================
-
-			logger.info('Starting KV sync...');
-
-			// Step 1: Get existing IP_RANGES from KV
-			const existingRanges = await getIpRanges(env.CROWDSECCFBOUNCERNS);
-
-			// Step 2: Check existing string decisions in KV (only on incremental updates, not first run)
-			let existingStringDecisions = new Map();
-
-			if (!isFirst) {
-				// On incremental updates, check existing values to avoid redundant writes
-				logger.debug('Incremental update: checking existing decisions in KV');
-				const allStringKeys = [
-					...decisions.new
-						.filter((d) => ['ip', 'as', 'country'].includes(d.scope))
-						.map((d) => (d.scope === 'country' ? d.value.toLowerCase() : d.value)),
-					...decisions.deleted
-						.filter((d) => ['ip', 'as', 'country'].includes(d.scope))
-						.map((d) => (d.scope === 'country' ? d.value.toLowerCase() : d.value)),
-				];
-
-				// Remove duplicates
-				const uniqueStringKeys = [...new Set(allStringKeys)];
-
-				// Fetch existing string decisions from KV using bulk API
-				existingStringDecisions = await batchGetStringBasedDecisions(
-					env.CF_ACCOUNT_ID,
-					env.CF_KV_NAMESPACE_ID,
-					env.CF_API_TOKEN,
-					uniqueStringKeys
-				);
-			} else {
-				logger.debug('First run: skipping existence check (KV is empty)');
-			}
-
-			// Step 3: Process new decisions
-			const newProcessed = processNewDecisions(decisions.new, existingStringDecisions, existingRanges);
-			// Step 4: Process deleted decisions
-			const deletedProcessed = processDeletedDecisions(decisions.deleted, existingStringDecisions, existingRanges);
-			// Step 5: Merge ranges (deletions already applied in step 4, now adding new ranges)
-			const finalRanges = mergeRanges(deletedProcessed.updatedRanges, newProcessed.jsonEntries);
-			// Step 6: Write new/updated string decisions (IP, AS, Country) to KV using bulk API
-			if (newProcessed.stringEntries.length > 0) {
-				logger.info('Writing string-based decisions to KV...', { count: newProcessed.stringEntries.length });
-				await batchWriteStringBasedDecisions(
-					env.CF_ACCOUNT_ID,
-					env.CF_KV_NAMESPACE_ID,
-					env.CF_API_TOKEN,
-					newProcessed.stringEntries
-				);
-			}
-			// Step 7: Delete string decisions from KV using bulk API
-			if (deletedProcessed.stringKeysToDelete.length > 0) {
-				logger.info('Deleting string decisions from KV...', { count: deletedProcessed.stringKeysToDelete.length });
-				await batchDeleteStringBasedDecisions(
-					env.CF_ACCOUNT_ID,
-					env.CF_KV_NAMESPACE_ID,
-					env.CF_API_TOKEN,
-					deletedProcessed.stringKeysToDelete
-				);
-			}
-			// Step 8: Update IP_RANGES if changed
-			if (hasRangesChanged(existingRanges, finalRanges)) {
-				logger.info('IP_RANGES changed, updating KV...');
-				await writeIpRanges(env.CROWDSECCFBOUNCERNS, finalRanges);
-			}
-
-            // Step 9: Mark cache as warmed after first successful fetch
-            if (isFirst) {
-                await markAsWarmed(env.CROWDSECCFBOUNCERNS);
-                logger.info('Cache marked as warmed after first fetch');
-            }
-
-			// Final summary
-			const finalDuration = ((Date.now() - startTime) / 1000).toFixed(2);
-
-			logger.info('KV sync completed successfully', {
-				totalDuration: `${finalDuration}s`,
-				stringWritten: newProcessed.stringEntries.length,
-				stringDeleted: deletedProcessed.stringKeysToDelete.length,
-				rangesCount: Object.keys(finalRanges).length,
-			});
 		} catch (error) {
 			const duration = ((Date.now() - startTime) / 1000).toFixed(2);
 			logger.error('Decision sync failed', {

--- a/pkg/cloudflare/metrics.sql
+++ b/pkg/cloudflare/metrics.sql
@@ -1,8 +1,0 @@
-CREATE TABLE IF NOT EXISTS metrics (
-  val INTEGER DEFAULT 1,
-  metric_name TEXT,
-  origin TEXT NOT NULL DEFAULT '',
-  remediation_type TEXT NOT NULL DEFAULT '',
-  ip_type TEXT NOT NULL DEFAULT '',
-  UNIQUE(metric_name, origin, remediation_type, ip_type)
-);

--- a/pkg/cloudflare/worker/dist/main.js
+++ b/pkg/cloudflare/worker/dist/main.js
@@ -7075,6 +7075,8 @@ const getSupportedActionForZone = (action, actionsForDomain) => {
   return actionsForDomain["default_action"];
 };
 
+const TURNSTILE_VERIFY_TIMEOUT_MS = 5000;
+
 const handleTurnstilePost = async (
   request,
   body,
@@ -7091,12 +7093,31 @@ const handleTurnstilePost = async (
   formData.append("remoteip", ip);
 
   const url = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
-  const result = await fetch(url, {
-    body: formData,
-    method: "POST",
-  });
 
-  const outcome = await result.json();
+  // If Turnstile siteverify hangs or errors, we can't decide — fail open to
+  // origin rather than block a user whose captcha submission we couldn't
+  // verify because Cloudflare's own verification API is unavailable.
+  let outcome;
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      TURNSTILE_VERIFY_TIMEOUT_MS,
+    );
+    try {
+      const result = await fetch(url, {
+        body: formData,
+        method: "POST",
+        signal: controller.signal,
+      });
+      outcome = await result.json();
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  } catch (e) {
+    console.error("Turnstile siteverify unavailable, passing to origin:", e);
+    return fetch(request);
+  }
 
   if (!outcome.success) {
     console.log("Invalid captcha solution");
@@ -7156,7 +7177,20 @@ const writeToKV = async (kv, key, value) => {
         "Unhandled error in worker, passing through to origin:",
         error,
       );
-      return fetch(request);
+      // Defensive double-wrap: if the origin pass-through itself throws (e.g.
+      // origin is unreachable), return a synthetic 502 so the runtime doesn't
+      // surface a 1101 "Worker threw exception" page on top of an existing
+      // outage. Either way the request fails; this just keeps the failure
+      // owned by the bouncer's contract instead of leaking implementation.
+      try {
+        return await fetch(request);
+      } catch (passthroughError) {
+        console.error(
+          "Origin pass-through also failed:",
+          passthroughError,
+        );
+        return new Response("", { status: 502 });
+      }
     }
   },
 

--- a/pkg/cloudflare/worker/dist/main.js
+++ b/pkg/cloudflare/worker/dist/main.js
@@ -7194,7 +7194,16 @@ const writeToKV = async (kv, key, value) => {
           console.error("Failed to parse turnstile config:", e);
           return fetch(request);
         }
-        writeToKV(env.CROWDSECCFBOUNCERNS, "TURNSTILE_CONFIG", turnstileCfg);
+        // ctx.waitUntil keeps the KV put alive after we return the response;
+        // otherwise the Workers runtime cancels the unawaited Promise and the
+        // normalised TURNSTILE_CONFIG never lands.
+        ctx.waitUntil(
+          writeToKV(
+            env.CROWDSECCFBOUNCERNS,
+            "TURNSTILE_CONFIG",
+            JSON.stringify(turnstileCfg),
+          ),
+        );
       }
 
       if (!turnstileCfg[zoneForThisRequest]) {
@@ -7368,31 +7377,22 @@ const writeToKV = async (kv, key, value) => {
       return null;
     };
 
-    const incrementMetrics = async (
+    const writeMetricEvent = (
       metricName,
       ipType,
       origin,
-      remediation_type,
+      remediationType,
+      latencyMs,
     ) => {
-      if (env.CROWDSECCFBOUNCERDB !== undefined) {
-        let parameters = [
-          metricName,
-          origin || "",
-          remediation_type || "",
-          ipType,
-        ];
-        let query = `
-          INSERT INTO metrics (val, metric_name, origin, remediation_type, ip_type)
-          VALUES (1, ?, ?, ?, ?)
-          ON CONFLICT(metric_name, origin, remediation_type, ip_type) DO UPDATE SET val=val+1
-        `;
-        try {
-          await env.CROWDSECCFBOUNCERDB.prepare(query)
-            .bind(...parameters)
-            .run();
-        } catch (error) {
-          console.error("Error incrementing metrics:", error);
-        }
+      if (!env.CROWDSECCFBOUNCER_AE) return;
+      try {
+        env.CROWDSECCFBOUNCER_AE.writeDataPoint({
+          indexes: [env.ACCOUNT_NAME || "default"],
+          blobs: [metricName, ipType, origin || "", remediationType || ""],
+          doubles: [1, latencyMs || 0],
+        });
+      } catch (e) {
+        console.error("AE write failed:", e);
       }
     };
 
@@ -7410,48 +7410,75 @@ const writeToKV = async (kv, key, value) => {
       return fetch(request);
     }
 
-    ctx.waitUntil(incrementMetrics("processed", ipType));
+    const start = Date.now();
+    let metricOrigin = "";
+    let metricRemediation = "";
+    let blocked = false;
+    let errored = false;
 
-    let remediation = await getRemediationForRequest(request, env);
-    if (remediation === null) {
-      console.log("No remediation found for request");
-      return fetch(request);
-    }
-    if (typeof env.ACTIONS_BY_DOMAIN === "string") {
-      try {
-        env.ACTIONS_BY_DOMAIN = JSON.parse(env.ACTIONS_BY_DOMAIN);
-      } catch (e) {
-        console.error("Failed to parse ACTIONS_BY_DOMAIN:", e);
+    try {
+      let remediation = await getRemediationForRequest(request, env);
+      if (remediation === null) {
+        console.log("No remediation found for request");
         return fetch(request);
       }
-    }
-    const zoneForThisRequest = getZoneFromReqURL(
-      request.url,
-      env.ACTIONS_BY_DOMAIN,
-    );
-    if (!zoneForThisRequest || !env.ACTIONS_BY_DOMAIN[zoneForThisRequest]) {
-      console.log("No matching zone found for request URL, passing through");
-      return fetch(request);
-    }
-    console.log("Zone for this request is " + zoneForThisRequest);
-    remediation = getSupportedActionForZone(
-      remediation,
-      env.ACTIONS_BY_DOMAIN[zoneForThisRequest],
-    );
-    console.log("Remediation for request is " + remediation);
-    switch (remediation) {
-      case "ban":
-        ctx.waitUntil(incrementMetrics("dropped", ipType, "crowdsec", "ban"));
-        return env.LOG_ONLY === "true" ? fetch(request) : await doBan();
-      case "captcha":
-        ctx.waitUntil(
-          incrementMetrics("dropped", ipType, "crowdsec", "captcha"),
-        );
-        return env.LOG_ONLY === "true"
-          ? fetch(request)
-          : await doCaptcha(env, zoneForThisRequest);
-      default:
+      if (typeof env.ACTIONS_BY_DOMAIN === "string") {
+        try {
+          env.ACTIONS_BY_DOMAIN = JSON.parse(env.ACTIONS_BY_DOMAIN);
+        } catch (e) {
+          console.error("Failed to parse ACTIONS_BY_DOMAIN:", e);
+          return fetch(request);
+        }
+      }
+      const zoneForThisRequest = getZoneFromReqURL(
+        request.url,
+        env.ACTIONS_BY_DOMAIN,
+      );
+      if (!zoneForThisRequest || !env.ACTIONS_BY_DOMAIN[zoneForThisRequest]) {
+        console.log("No matching zone found for request URL, passing through");
         return fetch(request);
+      }
+      console.log("Zone for this request is " + zoneForThisRequest);
+      remediation = getSupportedActionForZone(
+        remediation,
+        env.ACTIONS_BY_DOMAIN[zoneForThisRequest],
+      );
+      console.log("Remediation for request is " + remediation);
+      switch (remediation) {
+        case "ban":
+          blocked = true;
+          metricOrigin = "crowdsec";
+          metricRemediation = "ban";
+          return env.LOG_ONLY === "true" ? fetch(request) : await doBan();
+        case "captcha":
+          blocked = true;
+          metricOrigin = "crowdsec";
+          metricRemediation = "captcha";
+          return env.LOG_ONLY === "true"
+            ? fetch(request)
+            : await doCaptcha(env, zoneForThisRequest);
+        default:
+          return fetch(request);
+      }
+    } catch (e) {
+      // Record the error metric, then re-throw so the outer fetch() wrapper
+      // catches and passes the request through to origin (per #95).
+      errored = true;
+      throw e;
+    } finally {
+      const latencyMs = Date.now() - start;
+      writeMetricEvent("processed", ipType, "", "", latencyMs);
+      if (errored) {
+        writeMetricEvent("error", ipType, "", "", latencyMs);
+      } else if (blocked) {
+        writeMetricEvent(
+          "dropped",
+          ipType,
+          metricOrigin,
+          metricRemediation,
+          latencyMs,
+        );
+      }
     }
   },
 });

--- a/pkg/cloudflare/worker/worker.js
+++ b/pkg/cloudflare/worker/worker.js
@@ -19,6 +19,8 @@ const getSupportedActionForZone = (action, actionsForDomain) => {
   return actionsForDomain["default_action"];
 };
 
+const TURNSTILE_VERIFY_TIMEOUT_MS = 5000;
+
 const handleTurnstilePost = async (
   request,
   body,
@@ -35,12 +37,31 @@ const handleTurnstilePost = async (
   formData.append("remoteip", ip);
 
   const url = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
-  const result = await fetch(url, {
-    body: formData,
-    method: "POST",
-  });
 
-  const outcome = await result.json();
+  // If Turnstile siteverify hangs or errors, we can't decide — fail open to
+  // origin rather than block a user whose captcha submission we couldn't
+  // verify because Cloudflare's own verification API is unavailable.
+  let outcome;
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      TURNSTILE_VERIFY_TIMEOUT_MS,
+    );
+    try {
+      const result = await fetch(url, {
+        body: formData,
+        method: "POST",
+        signal: controller.signal,
+      });
+      outcome = await result.json();
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  } catch (e) {
+    console.error("Turnstile siteverify unavailable, passing to origin:", e);
+    return fetch(request);
+  }
 
   if (!outcome.success) {
     console.log("Invalid captcha solution");
@@ -100,7 +121,20 @@ export default {
         "Unhandled error in worker, passing through to origin:",
         error,
       );
-      return fetch(request);
+      // Defensive double-wrap: if the origin pass-through itself throws (e.g.
+      // origin is unreachable), return a synthetic 502 so the runtime doesn't
+      // surface a 1101 "Worker threw exception" page on top of an existing
+      // outage. Either way the request fails; this just keeps the failure
+      // owned by the bouncer's contract instead of leaking implementation.
+      try {
+        return await fetch(request);
+      } catch (passthroughError) {
+        console.error(
+          "Origin pass-through also failed:",
+          passthroughError,
+        );
+        return new Response("", { status: 502 });
+      }
     }
   },
 

--- a/pkg/cloudflare/worker/worker.js
+++ b/pkg/cloudflare/worker/worker.js
@@ -138,7 +138,16 @@ export default {
           console.error("Failed to parse turnstile config:", e);
           return fetch(request);
         }
-        writeToKV(env.CROWDSECCFBOUNCERNS, "TURNSTILE_CONFIG", turnstileCfg);
+        // ctx.waitUntil keeps the KV put alive after we return the response;
+        // otherwise the Workers runtime cancels the unawaited Promise and the
+        // normalised TURNSTILE_CONFIG never lands.
+        ctx.waitUntil(
+          writeToKV(
+            env.CROWDSECCFBOUNCERNS,
+            "TURNSTILE_CONFIG",
+            JSON.stringify(turnstileCfg),
+          ),
+        );
       }
 
       if (!turnstileCfg[zoneForThisRequest]) {
@@ -312,31 +321,22 @@ export default {
       return null;
     };
 
-    const incrementMetrics = async (
+    const writeMetricEvent = (
       metricName,
       ipType,
       origin,
-      remediation_type,
+      remediationType,
+      latencyMs,
     ) => {
-      if (env.CROWDSECCFBOUNCERDB !== undefined) {
-        let parameters = [
-          metricName,
-          origin || "",
-          remediation_type || "",
-          ipType,
-        ];
-        let query = `
-          INSERT INTO metrics (val, metric_name, origin, remediation_type, ip_type)
-          VALUES (1, ?, ?, ?, ?)
-          ON CONFLICT(metric_name, origin, remediation_type, ip_type) DO UPDATE SET val=val+1
-        `;
-        try {
-          await env.CROWDSECCFBOUNCERDB.prepare(query)
-            .bind(...parameters)
-            .run();
-        } catch (error) {
-          console.error("Error incrementing metrics:", error);
-        }
+      if (!env.CROWDSECCFBOUNCER_AE) return;
+      try {
+        env.CROWDSECCFBOUNCER_AE.writeDataPoint({
+          indexes: [env.ACCOUNT_NAME || "default"],
+          blobs: [metricName, ipType, origin || "", remediationType || ""],
+          doubles: [1, latencyMs || 0],
+        });
+      } catch (e) {
+        console.error("AE write failed:", e);
       }
     };
 
@@ -354,48 +354,75 @@ export default {
       return fetch(request);
     }
 
-    ctx.waitUntil(incrementMetrics("processed", ipType));
+    const start = Date.now();
+    let metricOrigin = "";
+    let metricRemediation = "";
+    let blocked = false;
+    let errored = false;
 
-    let remediation = await getRemediationForRequest(request, env);
-    if (remediation === null) {
-      console.log("No remediation found for request");
-      return fetch(request);
-    }
-    if (typeof env.ACTIONS_BY_DOMAIN === "string") {
-      try {
-        env.ACTIONS_BY_DOMAIN = JSON.parse(env.ACTIONS_BY_DOMAIN);
-      } catch (e) {
-        console.error("Failed to parse ACTIONS_BY_DOMAIN:", e);
+    try {
+      let remediation = await getRemediationForRequest(request, env);
+      if (remediation === null) {
+        console.log("No remediation found for request");
         return fetch(request);
       }
-    }
-    const zoneForThisRequest = getZoneFromReqURL(
-      request.url,
-      env.ACTIONS_BY_DOMAIN,
-    );
-    if (!zoneForThisRequest || !env.ACTIONS_BY_DOMAIN[zoneForThisRequest]) {
-      console.log("No matching zone found for request URL, passing through");
-      return fetch(request);
-    }
-    console.log("Zone for this request is " + zoneForThisRequest);
-    remediation = getSupportedActionForZone(
-      remediation,
-      env.ACTIONS_BY_DOMAIN[zoneForThisRequest],
-    );
-    console.log("Remediation for request is " + remediation);
-    switch (remediation) {
-      case "ban":
-        ctx.waitUntil(incrementMetrics("dropped", ipType, "crowdsec", "ban"));
-        return env.LOG_ONLY === "true" ? fetch(request) : await doBan();
-      case "captcha":
-        ctx.waitUntil(
-          incrementMetrics("dropped", ipType, "crowdsec", "captcha"),
-        );
-        return env.LOG_ONLY === "true"
-          ? fetch(request)
-          : await doCaptcha(env, zoneForThisRequest);
-      default:
+      if (typeof env.ACTIONS_BY_DOMAIN === "string") {
+        try {
+          env.ACTIONS_BY_DOMAIN = JSON.parse(env.ACTIONS_BY_DOMAIN);
+        } catch (e) {
+          console.error("Failed to parse ACTIONS_BY_DOMAIN:", e);
+          return fetch(request);
+        }
+      }
+      const zoneForThisRequest = getZoneFromReqURL(
+        request.url,
+        env.ACTIONS_BY_DOMAIN,
+      );
+      if (!zoneForThisRequest || !env.ACTIONS_BY_DOMAIN[zoneForThisRequest]) {
+        console.log("No matching zone found for request URL, passing through");
         return fetch(request);
+      }
+      console.log("Zone for this request is " + zoneForThisRequest);
+      remediation = getSupportedActionForZone(
+        remediation,
+        env.ACTIONS_BY_DOMAIN[zoneForThisRequest],
+      );
+      console.log("Remediation for request is " + remediation);
+      switch (remediation) {
+        case "ban":
+          blocked = true;
+          metricOrigin = "crowdsec";
+          metricRemediation = "ban";
+          return env.LOG_ONLY === "true" ? fetch(request) : await doBan();
+        case "captcha":
+          blocked = true;
+          metricOrigin = "crowdsec";
+          metricRemediation = "captcha";
+          return env.LOG_ONLY === "true"
+            ? fetch(request)
+            : await doCaptcha(env, zoneForThisRequest);
+        default:
+          return fetch(request);
+      }
+    } catch (e) {
+      // Record the error metric, then re-throw so the outer fetch() wrapper
+      // catches and passes the request through to origin (per #95).
+      errored = true;
+      throw e;
+    } finally {
+      const latencyMs = Date.now() - start;
+      writeMetricEvent("processed", ipType, "", "", latencyMs);
+      if (errored) {
+        writeMetricEvent("error", ipType, "", "", latencyMs);
+      } else if (blocked) {
+        writeMetricEvent(
+          "dropped",
+          ipType,
+          metricOrigin,
+          metricRemediation,
+          latencyMs,
+        );
+      }
     }
   },
 };

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -40,3 +40,13 @@ var TotalActiveDecisions = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: ActiveDecisionsMetricName,
 	Help: "Total number of active decisions",
 }, []string{"origin", "ip_type", "scope", "account"})
+
+var TotalErrors = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "crowdsec_cloudflare_worker_bouncer_errors",
+	Help: "Total number of requests that threw an exception in the worker",
+}, []string{"ip_type", "account"})
+
+var AverageLatencyMs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "crowdsec_cloudflare_worker_bouncer_avg_latency_ms",
+	Help: "Average request processing latency in milliseconds",
+}, []string{"account", "metric_name", "ip_type", "remediation"})


### PR DESCRIPTION
## Motivation

D1 was a square peg in a round hole for per-request metrics. Three structural problems with D1 as the metrics store, none of which #96's `ctx.waitUntil` fully solves:

1. **Location pinning.** D1 is single-region; placement is fixed at creation time based on the API origin. A CI runner deploying from one region pins the metrics DB to that region forever, so every worker write — from every Cloudflare edge — pays that round-trip. The operator has no knob to influence placement short of recreating the database. Deploy-machine geography becomes a hidden production-performance input.

2. **Worker CPU per request.** #96 correctly moved the D1 write off the response-blocking path via `ctx.waitUntil`, so client-facing latency is unaffected. But every protected request still spends worker CPU time on `.prepare(query).bind(...).run()` to push one row through D1's SQL pipeline. AE `writeDataPoint` is a microsecond-scale buffered call shipped async by the runtime.

3. **Row-based store for aggregate data.** Metrics are aggregate by definition. D1 charges per row read/written and is row-shaped; AE is column-shaped, purpose-built for high-cardinality time-series, and aggregates at query time via SQL over blobs/doubles/indexes.

Workers Analytics Engine is region-agnostic, fire-and-forget at the edge, and the intended store for this access pattern. The Go control plane reads aggregated rows back via the AE SQL API on the existing csbouncer push schedule.

This PR also adds request-latency + worker-exception data points, Workers Observability config, and multi-instance isolation so multiple bouncer instances can share one Cloudflare account.

Follows the discussions with the CrowdSec team and the issues raised previously.

## What changes

**Metrics: D1 → Analytics Engine**
- Worker writes data points via `env.CROWDSECCFBOUNCER_AE.writeDataPoint` instead of D1 `INSERT … ON CONFLICT`.
- Go control plane polls the AE SQL API on the existing csbouncer push schedule using a half-open `[lastPoll, windowEnd)` window so every second is counted exactly once. `windowEnd` lags wall-clock by 10s to skip the AE indexing boundary — late-arriving rows land in the next poll instead of being stepped over.
- New Prometheus gauges: `crowdsec_cloudflare_bouncer_total_errors`, `crowdsec_cloudflare_bouncer_avg_latency_ms`.
- D1 schema (`metrics.sql`), bindings, and embed directive removed. A one-release migration shim (`cleanupLegacyD1Databases`) deletes the old `CROWDSECCFBOUNCERDB` D1 database on next startup if the token still has `D1:Edit`; logs a warning if not.

**Worker resilience (preserved from #95/#96 + tightened)**
- All `JSON.parse` try/catches, `request.cf` null guards, `formData` try/catch, `clientIP` null guard, `ipType` parse try/catch, and zone-miss guard are kept on top of the metrics refactor.
- The exception path inside `_handleFetch` records an `error` AE data point in `finally`, then re-throws so the outer `fetch()` wrapper from #95 catches and passes the request through to origin (fail-open). Verified in staging with malformed inputs.
- TURNSTILE_CONFIG KV write-back fix: parsed object is now serialised back as a JSON string (was writing `[object Object]`); wrapped in `ctx.waitUntil` so the runtime doesn't cancel the unawaited Promise.
- Turnstile `siteverify` POST wrapped in a 5s `AbortController` timeout: if Cloudflare's own verification API stalls or errors, the worker fails open to origin rather than blocking a user whose captcha can't be verified.
- The outer `fetch()` fallback in the top-level wrapper is double-wrapped: if both `_handleFetch` and the origin pass-through throw (e.g. worker error during an origin outage), the worker returns a synthetic 502 instead of letting the runtime surface a `1101 Worker threw exception` page on top of an existing outage.

**Decisions-sync-worker correctness**
- `markAsWarmed` runs only after all KV decision writes succeed (was running before, leaving `WARMED_UP=true` with empty KV on mid-sync crash → permanent enforcement gap).
- New `SYNC_IN_PROGRESS` KV lock with 300s TTL backstop + try/finally release. Best-effort (KV has no atomic put-if-absent — documented in `tryAcquireSyncLock` JSDoc); LAPI rate limiting is the actual safety net.

**Multi-instance support**
- `kv_namespace_name`, `decisions_sync_script_name` exposed as YAML knobs (defaults preserved → backward compatible).
- KV namespace teardown now does **positive attribution**: queries `ListWorkerBindings` before deleting worker scripts to identify this instance's namespace ID, deletes only that ID. Title-match remains as fallback when no worker is deployed, with a loud Warn log enumerating namespace IDs.
- `KVWorkerBindingName` / `AEWorkerBindingName` constants decouple worker JS env binding names from the configurable Cloudflare resource names.

**Workers Observability**
- Optional `observability` config block (off by default) enables Workers logs/traces via the `script-settings` API. Currently hand-rolled HTTP because `cloudflare-go v0.116` doesn't surface the field; collapse to SDK once a newer SDK is in scope.
- Observability failures log a Warn but do not abort deploy (it's a DX feature, shouldn't fail an otherwise-live worker).

**Security**
- The new AE polling query interpolates `account_name` and `analytics_dataset` (one as a quoted ClickHouse string literal, one as an unquoted identifier). Both are allowlist-validated at config load (`^[\p{L}\p{N} ._\-()&+@:,]*$` and `^[a-zA-Z_][a-zA-Z0-9_]{0,63}$` respectively) so interpolation can't escape its context — the only two ClickHouse metacharacters that could break out of, or escape within, a string literal (`'` and `\`) are rejected at the gate. No runtime escaping is needed.
- The worker writes only bounded enum strings + a count and latency double to AE — no IP, no cookies, no JWT content, no request bodies. Exception objects go to Workers logs only, never to AE.
- LAPI_KEY and CF_API_TOKEN remain bound as encrypted Workers Secrets.
- No new Go or npm dependencies.

## Migration notes for operators

- **Required**: add `Account Analytics:Read` to your Cloudflare API token. Without it the metric poll returns 403; remediation enforcement is unaffected.
- On first run, the bouncer auto-deletes the legacy `CROWDSECCFBOUNCERDB` D1 database if the token still has `D1:Edit`; otherwise logs a warning to delete it manually via the dashboard. The cleanup shim is intentionally temporary — remove after next release.
- `analytics_dataset` defaults to `crowdsec_cloudflare_bouncer` — no config change needed for single-instance deployments.
- Account names are now allowlist-validated at config load (SQL-injection defense). A name with disallowed characters (most notably `'` or `\`) is now a startup error; ConfigTokens' `-g` mode falls back to account ID when generating, so existing CF accounts with `'s Account` suffixes still work.
- Brief metrics gap during cutover as AE starts from zero — expected.

## Testing

- `make build`, `make lint` (golangci-lint v2), `go test ./...` — green.
- 1,000+ LoC of new unit tests in `cloudflare_test.go` and `config_test.go` covering AE polling (happy path, error paths, half-open window, advances-timestamp, query-interpolation safety, concurrent safety), KV cleanup positive attribution + fallback, legacy-D1 cleanup, observability, and config validation including SQL-injection payloads.
- **Staging deploy on a non-production Cloudflare account** verified across two full deploy/teardown cycles:
  - Positive-attribution KV teardown logged each time: `Deleting KV namespace "CROWDSECCFBOUNCERNS-STAGING" (id: …, attributed via worker binding)`.
  - Sync-worker failure path: when LAPI auth failed at staging, `WARMED_UP` correctly NOT set, `SYNC_IN_PROGRESS` released by `finally` block — no permanent enforcement gap.
  - k6 smoke (10 req/s × 30s): 0 bouncer errors, 100% reached origin via CF edge.
  - k6 ramp (10→100 req/s × 3.5min): 93% success; the 6.6% tail were backend-saturation timeouts, not worker overhead (worker path is a single KV read).
  - Multi-instance config knobs (`kv_namespace_name=CROWDSECCFBOUNCERNS-STAGING`, custom script names) deployed cleanly.
  - Workers Observability config applied: `Configured observability for crowdsec-bouncer-staging (logs=true/1.00, traces=true/1.00)`.

## Notes for reviewers

- The first commit (`fix(worker): persist TURNSTILE_CONFIG …`) bundles both the TURNSTILE fix and the worker-side D1→AE migration since they live in the same file; the commit title undersells the scope slightly. The story reads commit-by-commit as: (1) worker-side changes, (2) sync-worker correctness, (3) Go-side AE migration + multi-instance, (4) rebuilt webpack bundles, (5) further fail-open hardening on the Turnstile verify and outer pass-through.
- Bundled `dist/main.js` artifacts are committed (matches `#95`/`#96` convention) and were rebuilt from source via `npm ci && npm run build`.
- `cloudflare-go` is unchanged at v0.116.0; the `enableWorkerObservability` hand-rolled HTTP can collapse to an SDK call once a newer cloudflare-go is in scope upstream.

## Follow-ups (out of scope for this PR)

- Convert metric gauges to `prometheus.CounterVec` (currently pre-existing pattern in upstream uses Gauges for counter semantics; touching it changes the metric type, which would break operator dashboards — worth a separate proposal).
- Bump `cloudflare-go` to a version that exposes observability, collapse the hand-rolled PATCH.
- Multi-instance teardown could require `--force-title-cleanup` for the fallback path; this PR ships the WARN-based approach.
